### PR TITLE
Fix submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,4 @@
 [submodule "submodules/chainlink-protos"]
 	path = submodules/chainlink-protos
 	url = https://github.com/smartcontractkit/chainlink-protos.git
-[submodule "submodules/chainlink-common"]
-	path = submodules/chainlink-common
-	url = https://github.com/smartcontractkit/chainlink-common.git
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project uses Git submodules to include external dependencies. After cloning
 
 ```zsh
 # Clone with submodules
-git clone --recursive https://github.com/ernest-nowacki/cre-ts-sdk.git
+git clone --recursive https://github.com/smartcontractkit/cre-sdk-typescript
 
 # Or if already cloned without submodules
 git submodule update --init --recursive
@@ -43,10 +43,9 @@ cd ../..
 
 If you need to make changes to the submodule, it's recommended to contribute to the original repository, following all the contribution guidelines, and then once the changes are merged, update the submodule to the latest version.
 
-Currently sdk uses two submodules:
+Currently sdk uses submodules:
 
 - chainlink-protos - for protobuf definitions
-- chainlink-common - for extra protobuf definitions for test capabilities
 
 ## Setup
 

--- a/src/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen.ts
@@ -15,25 +15,27 @@ import {
 
 /**
  * Client Capability
- *
+ * 
  * Capability ID: http-actions@1.0.0-alpha
  * Default Mode: Mode.NODE
  */
 export class ClientCapability {
   /** The capability ID for this service */
   static readonly CAPABILITY_ID = "http-actions@1.0.0-alpha";
-
+  
   /** The default execution mode for this capability */
   static readonly DEFAULT_MODE = Mode.NODE;
 
-  constructor(private readonly mode: Mode = ClientCapability.DEFAULT_MODE) {}
+  constructor(
+    private readonly mode: Mode = ClientCapability.DEFAULT_MODE
+  ) {}
 
   async sendRequest(input: RequestJson): Promise<Response> {
     const payload = {
       typeUrl: getTypeUrl(RequestSchema),
       value: toBinary(RequestSchema, fromJson(RequestSchema, input)),
     };
-
+    
     return callCapability({
       capabilityId: ClientCapability.CAPABILITY_ID,
       method: "SendRequest",
@@ -56,10 +58,7 @@ export class ClientCapability {
         });
       }
 
-      return fromBinary(
-        ResponseSchema,
-        capabilityResponse.response.value.value
-      );
+      return fromBinary(ResponseSchema, capabilityResponse.response.value.value);
     });
   }
 }

--- a/src/generated/values/v1/values_pb.ts
+++ b/src/generated/values/v1/values_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file values/v1/values.proto.
  */
 export const file_values_v1_values: GenFile = /*@__PURE__*/
-  fileDesc("ChZ2YWx1ZXMvdjEvdmFsdWVzLnByb3RvEgl2YWx1ZXMudjEi5QIKBVZhbHVlEhYKDHN0cmluZ192YWx1ZRgBIAEoCUgAEhQKCmJvb2xfdmFsdWUYAiABKAhIABIVCgtieXRlc192YWx1ZRgDIAEoDEgAEiMKCW1hcF92YWx1ZRgEIAEoCzIOLnZhbHVlcy52MS5NYXBIABIlCgpsaXN0X3ZhbHVlGAUgASgLMg8udmFsdWVzLnYxLkxpc3RIABIrCg1kZWNpbWFsX3ZhbHVlGAYgASgLMhIudmFsdWVzLnYxLkRlY2ltYWxIABIZCgtpbnQ2NF92YWx1ZRgHIAEoA0ICMAFIABIpCgxiaWdpbnRfdmFsdWUYCSABKAsyES52YWx1ZXMudjEuQmlnSW50SAASMAoKdGltZV92YWx1ZRgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIABIXCg1mbG9hdDY0X3ZhbHVlGAsgASgBSABCBwoFdmFsdWVKBAgIEAkiKwoGQmlnSW50Eg8KB2Fic192YWwYASABKAwSEAoEc2lnbhgCIAEoA0ICMAEicgoDTWFwEioKBmZpZWxkcxgBIAMoCzIaLnZhbHVlcy52MS5NYXAuRmllbGRzRW50cnkaPwoLRmllbGRzRW50cnkSCwoDa2V5GAEgASgJEh8KBXZhbHVlGAIgASgLMhAudmFsdWVzLnYxLlZhbHVlOgI4ASIoCgRMaXN0EiAKBmZpZWxkcxgCIAMoCzIQLnZhbHVlcy52MS5WYWx1ZSJDCgdEZWNpbWFsEiYKC2NvZWZmaWNpZW50GAEgASgLMhEudmFsdWVzLnYxLkJpZ0ludBIQCghleHBvbmVudBgCIAEoBUJhCg1jb20udmFsdWVzLnYxQgtWYWx1ZXNQcm90b1ABogIDVlhYqgIJVmFsdWVzLlYxygIJVmFsdWVzXFYx4gIVVmFsdWVzXFYxXEdQQk1ldGFkYXRh6gIKVmFsdWVzOjpWMWIGcHJvdG8z", [file_google_protobuf_timestamp]);
+  fileDesc("ChZ2YWx1ZXMvdjEvdmFsdWVzLnByb3RvEgl2YWx1ZXMudjEigQMKBVZhbHVlEhYKDHN0cmluZ192YWx1ZRgBIAEoCUgAEhQKCmJvb2xfdmFsdWUYAiABKAhIABIVCgtieXRlc192YWx1ZRgDIAEoDEgAEiMKCW1hcF92YWx1ZRgEIAEoCzIOLnZhbHVlcy52MS5NYXBIABIlCgpsaXN0X3ZhbHVlGAUgASgLMg8udmFsdWVzLnYxLkxpc3RIABIrCg1kZWNpbWFsX3ZhbHVlGAYgASgLMhIudmFsdWVzLnYxLkRlY2ltYWxIABIZCgtpbnQ2NF92YWx1ZRgHIAEoA0ICMAFIABIpCgxiaWdpbnRfdmFsdWUYCSABKAsyES52YWx1ZXMudjEuQmlnSW50SAASMAoKdGltZV92YWx1ZRgKIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXBIABIXCg1mbG9hdDY0X3ZhbHVlGAsgASgBSAASGgoMdWludDY0X3ZhbHVlGAwgASgEQgIwAUgAQgcKBXZhbHVlSgQICBAJIisKBkJpZ0ludBIPCgdhYnNfdmFsGAEgASgMEhAKBHNpZ24YAiABKANCAjABInIKA01hcBIqCgZmaWVsZHMYASADKAsyGi52YWx1ZXMudjEuTWFwLkZpZWxkc0VudHJ5Gj8KC0ZpZWxkc0VudHJ5EgsKA2tleRgBIAEoCRIfCgV2YWx1ZRgCIAEoCzIQLnZhbHVlcy52MS5WYWx1ZToCOAEiKAoETGlzdBIgCgZmaWVsZHMYAiADKAsyEC52YWx1ZXMudjEuVmFsdWUiQwoHRGVjaW1hbBImCgtjb2VmZmljaWVudBgBIAEoCzIRLnZhbHVlcy52MS5CaWdJbnQSEAoIZXhwb25lbnQYAiABKAVCYQoNY29tLnZhbHVlcy52MUILVmFsdWVzUHJvdG9QAaICA1ZYWKoCCVZhbHVlcy5WMcoCCVZhbHVlc1xWMeICFVZhbHVlc1xWMVxHUEJNZXRhZGF0YeoCClZhbHVlczo6VjFiBnByb3RvMw", [file_google_protobuf_timestamp]);
 
 /**
  * @generated from message values.v1.Value
@@ -81,6 +81,12 @@ export type Value = Message<"values.v1.Value"> & {
      */
     value: number;
     case: "float64Value";
+  } | {
+    /**
+     * @generated from field: uint64 uint64_value = 12 [jstype = JS_STRING];
+     */
+    value: string;
+    case: "uint64Value";
   } | { case: undefined; value?: undefined };
 };
 
@@ -137,6 +143,11 @@ export type ValueJson = {
    * @generated from field: double float64_value = 11;
    */
   float64Value?: number | "NaN" | "Infinity" | "-Infinity";
+
+  /**
+   * @generated from field: uint64 uint64_value = 12 [jstype = JS_STRING];
+   */
+  uint64Value?: string;
 };
 
 /**


### PR DESCRIPTION
This pull request primarily removes the `chainlink-common` submodule from the project and updates documentation to reflect this change. It also includes minor code formatting improvements in the HTTP client capability and updates the `chainlink-protos` submodule to a new commit.

**Submodule changes:**

* Removed the `chainlink-common` submodule entry from `.gitmodules`, and updated documentation in `README.md` to no longer mention `chainlink-common` as a dependency. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-L49)
* Updated the `chainlink-protos` submodule to commit `3da0976c39d2e39ce944cbc15b4da0a6a824e523`.

**Documentation updates:**

* Changed the clone URL in `README.md` to point to the canonical repository (`smartcontractkit/cre-sdk-typescript`) instead of a fork.

**Code formatting improvements:**

* Reformatted the constructor in `ClientCapability` for improved readability and compacted the `fromBinary` call in the `sendRequest` method in `src/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen.ts`. [[1]](diffhunk://#diff-51fd32ba36806d7603b9bef58cb3596f9d136c4b7c3eb94c2e6f89e8f04a92feL29-R31) [[2]](diffhunk://#diff-51fd32ba36806d7603b9bef58cb3596f9d136c4b7c3eb94c2e6f89e8f04a92feL59-R61)