### PR TITLE
Typescript issues fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ standard_tests:
 	-test.skip="$(SKIP_TESTS)"
 
 # Run a single test by name
-# Usage: make standard_test_single TEST=TestStandardCapabilityRegistration
+# Usage: make standard_test_single TEST=TestStandardCapabilityCallsAreAsync
 standard_test_single:
 	@if [ -z "$(TEST)" ]; then \
 		echo "Error: TEST parameter is required. Usage: make standard_test_single TEST=TestName"; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 COMMON_VERSION ?= cre-std-tests@0.4.0
 MODULE := github.com/smartcontractkit/chainlink-common
+TEST_PATTERN ?= ^TestStandard
+SKIP_TESTS ?= TestStandardCapabilityCallsAreAsync|TestStandardSecretsFailInNodeMode|TestStandardModeSwitch/successful_mode_switch
 
-.PHONY: standard_tests
+.PHONY: standard_tests standard_test_single
 standard_tests:
 	@echo "Downloading standard test version $(COMMON_VERSION)"
 	mkdir -p .tools
@@ -11,6 +13,16 @@ standard_tests:
 	echo "Building standard tests"; \
 	( cd $$mod_dir/pkg/workflows/wasm/host && go test -c -o $$abs_dir/host.test . ); \
 	echo "Running standard tests"; \
-	$$abs_dir/host.test -test.v -test.run ^TestStandard \
+	$$abs_dir/host.test -test.v -test.run $(TEST_PATTERN) \
 	-path=dist/workflows/standard_tests \
-	-test.skip="TestStandardCapabilityCallsAreAsync|TestStandardSecretsFailInNodeMode|TestStandardModeSwitch/successful_mode_switch"
+	-test.skip="$(SKIP_TESTS)"
+
+# Run a single test by name
+# Usage: make standard_test_single TEST=TestStandardCapabilityRegistration
+standard_test_single:
+	@if [ -z "$(TEST)" ]; then \
+		echo "Error: TEST parameter is required. Usage: make standard_test_single TEST=TestName"; \
+		exit 1; \
+	fi
+	@echo "Running single test: $(TEST)"
+	@$(MAKE) standard_tests TEST_PATTERN="^$(TEST)$$" SKIP_TESTS=""

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:workflow:single:js": "bun scripts/run.ts build-single-workflow-js",
     "build:workflow:single:wasm": "bun scripts/run.ts compile-single-workflow-to-wasm",
     "build:workflow:single": "bun scripts/run.ts build-single-workflow",
-    "build:all": "bun build.ts",
+    "build:all": "bun typecheck && bun build.ts",
     "javy": "./bin/javy-arm-macos-v5.0.4",
     "javy:linux": "./bin/javy-arm-linux-v5.0.4",
     "start": "bun --watch src/index.ts",

--- a/src/sdk/engine/execute.test.ts
+++ b/src/sdk/engine/execute.test.ts
@@ -15,18 +15,20 @@ import { getTypeUrl } from "@cre/sdk/utils/typeurl";
 import { emptyConfig, basicRuntime } from "@cre/sdk/testhelpers/mocks";
 
 // Mock the hostBindings module before importing handleExecuteRequest
-const mockSendResponse = mock((_response: string) => 0);
+const mockSendResponse = mock((_response: Uint8Array) => 0);
 const mockHostBindings = {
   sendResponse: mockSendResponse,
   switchModes: mock((_mode: 0 | 1 | 2) => {}),
   log: mock((_message: string) => {}),
-  callCapability: mock((_request: string) => 1),
-  awaitCapabilities: mock((_awaitRequest: string, _maxResponseLen: number) =>
-    btoa("mock_await_capabilities_response")
+  callCapability: mock((_request: Uint8Array) => 1),
+  awaitCapabilities: mock(
+    (_awaitRequest: Uint8Array, _maxResponseLen: number) =>
+      new Uint8Array(Buffer.from("mock_await_capabilities_response", "utf8"))
   ),
-  getSecrets: mock((_request: string, _maxResponseLen: number) => 1),
-  awaitSecrets: mock((_awaitRequest: string, _maxResponseLen: number) =>
-    btoa("mock_await_secrets_response")
+  getSecrets: mock((_request: Uint8Array, _maxResponseLen: number) => 1),
+  awaitSecrets: mock(
+    (_awaitRequest: Uint8Array, _maxResponseLen: number) =>
+      new Uint8Array(Buffer.from("mock_await_secrets_response", "utf8"))
   ),
   versionV2: mock(() => {}),
   randomSeed: mock((_mode: 1 | 2) => Math.random()),

--- a/src/sdk/utils/secrets/do-get-secret.ts
+++ b/src/sdk/utils/secrets/do-get-secret.ts
@@ -7,6 +7,7 @@ import {
   getLastCallbackId,
   incrementCallbackId,
 } from "@cre/sdk/utils/capabilities/callback-id";
+import { hostBindings } from "@cre/sdk/runtime/host-bindings";
 
 export const doGetSecret = (id: string) => {
   const callbackId = getLastCallbackId(Mode.DON);
@@ -17,8 +18,8 @@ export const doGetSecret = (id: string) => {
     callbackId,
   });
 
-  getSecrets(
-    Buffer.from(toBinary(GetSecretsRequestSchema, request)).toString("utf-8"),
+  hostBindings.getSecrets(
+    toBinary(GetSecretsRequestSchema, request),
     1024 * 1024
   );
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,15 +1,17 @@
 import { mock, beforeEach } from "bun:test";
 
 // Mock CRE globals
-globalThis.callCapability = mock((_request: string) => 1);
+globalThis.callCapability = mock((_request: Uint8Array) => 1);
 globalThis.awaitCapabilities = mock(
-  (_awaitRequest: string, _maxResponseLen: number) =>
-    btoa("mock_await_cabilities_response")
+  (_awaitRequest: Uint8Array, _maxResponseLen: number) =>
+    new Uint8Array(Buffer.from("mock_await_cabilities_response", "utf8"))
 );
-globalThis.getSecrets = mock((_request: string, _maxResponseLen: number) => 1);
+globalThis.getSecrets = mock(
+  (_request: Uint8Array, _maxResponseLen: number) => 1
+);
 globalThis.awaitSecrets = mock(
-  (_awaitRequest: string, _maxResponseLen: number) =>
-    btoa("mock_await_secrets_response")
+  (_awaitRequest: Uint8Array, _maxResponseLen: number) =>
+    new Uint8Array(Buffer.from("mock_await_secrets_response", "utf8"))
 );
 globalThis.log = mock((message: string) => console.log(message));
 globalThis.sendResponse = mock((_response: Uint8Array) => 0);


### PR DESCRIPTION
- satisfy TypeScript (`bun typecheck` no longer errors out)
- add typechecking as a part of the `build:all` step
- add an option to run single `standard_test` to make debugging easier