### PR TITLE
Fix Inconsistent Error Handling in install.js

### DIFF
--- a/install.js
+++ b/install.js
@@ -103,6 +103,7 @@ function isPlatformSpecificPackageInstalled() {
     require.resolve(`${platformSpecificPackageName}/bin/${binaryName}`)
     return true
   } catch (e) {
+    console.warn(`Could not resolve platform-specific package: ${platformSpecificPackageName}. Falling back to manual download. Error:`, e.message);
     return false
   }
 }


### PR DESCRIPTION
This change addresses an issue where the install.js script was catching and suppressing errors within the isPlatformSpecificPackageInstalled function. By adding a console.warn statement to the catch block, we can now log any errors that occur, making it easier to debug installation failures.