### PR TITLE
fix: await callCapability in action generator

### DIFF
--- a/src/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen.ts
@@ -2,7 +2,7 @@ import { fromBinary, toBinary, fromJson, create } from '@bufbuild/protobuf'
 import { Mode, type CapabilityResponse } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { callCapability } from '@cre/sdk/utils/capabilities/call-capability'
 import { CapabilityError } from '@cre/sdk/utils/capabilities/capability-error'
-import type { Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
+import { type Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
 import { type Any, AnySchema } from '@bufbuild/protobuf/wkt'
 import { getTypeUrl } from '@cre/sdk/utils/typeurl'
 import {
@@ -116,30 +116,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'CallContract',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'CallContract',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'CallContract',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(CallContractReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'CallContract',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'CallContract',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(CallContractReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async filterLogs(input: FilterLogsRequest | FilterLogsRequestJson): Promise<FilterLogsReply> {
@@ -156,30 +156,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'FilterLogs',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'FilterLogs',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'FilterLogs',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(FilterLogsReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'FilterLogs',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'FilterLogs',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(FilterLogsReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async balanceAt(input: BalanceAtRequest | BalanceAtRequestJson): Promise<BalanceAtReply> {
@@ -196,30 +196,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'BalanceAt',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'BalanceAt',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'BalanceAt',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(BalanceAtReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'BalanceAt',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'BalanceAt',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(BalanceAtReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async estimateGas(input: EstimateGasRequest | EstimateGasRequestJson): Promise<EstimateGasReply> {
@@ -236,30 +236,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'EstimateGas',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'EstimateGas',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'EstimateGas',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(EstimateGasReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'EstimateGas',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'EstimateGas',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(EstimateGasReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async getTransactionByHash(
@@ -278,30 +278,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'GetTransactionByHash',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'GetTransactionByHash',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'GetTransactionByHash',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(GetTransactionByHashReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'GetTransactionByHash',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'GetTransactionByHash',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(GetTransactionByHashReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async getTransactionReceipt(
@@ -320,30 +320,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'GetTransactionReceipt',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'GetTransactionReceipt',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'GetTransactionReceipt',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(GetTransactionReceiptReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'GetTransactionReceipt',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'GetTransactionReceipt',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(GetTransactionReceiptReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async headerByNumber(
@@ -362,30 +362,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'HeaderByNumber',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'HeaderByNumber',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'HeaderByNumber',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(HeaderByNumberReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'HeaderByNumber',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'HeaderByNumber',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(HeaderByNumberReplySchema, capabilityResponse.response.value.value)
 	}
 
 	async registerLogTracking(
@@ -404,30 +404,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'RegisterLogTracking',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'RegisterLogTracking',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'RegisterLogTracking',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(EmptySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'RegisterLogTracking',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'RegisterLogTracking',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(EmptySchema, capabilityResponse.response.value.value)
 	}
 
 	async unregisterLogTracking(
@@ -446,30 +446,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'UnregisterLogTracking',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'UnregisterLogTracking',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'UnregisterLogTracking',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(EmptySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'UnregisterLogTracking',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'UnregisterLogTracking',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(EmptySchema, capabilityResponse.response.value.value)
 	}
 
 	logTrigger(config: FilterLogTriggerRequestJson): ClientLogTrigger {
@@ -490,30 +490,30 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'WriteReport',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'WriteReport',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'WriteReport',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(WriteReportReplySchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'WriteReport',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'WriteReport',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(WriteReportReplySchema, capabilityResponse.response.value.value)
 	}
 }
 

--- a/src/generated-sdk/capabilities/internal/actionandtrigger/v1/basic_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/actionandtrigger/v1/basic_sdk_gen.ts
@@ -2,7 +2,7 @@ import { fromBinary, toBinary, fromJson, create } from '@bufbuild/protobuf'
 import { Mode, type CapabilityResponse } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { callCapability } from '@cre/sdk/utils/capabilities/call-capability'
 import { CapabilityError } from '@cre/sdk/utils/capabilities/capability-error'
-import type { Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
+import { type Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
 import { type Any, AnySchema } from '@bufbuild/protobuf/wkt'
 import { getTypeUrl } from '@cre/sdk/utils/typeurl'
 import {
@@ -49,30 +49,30 @@ export class BasicCapability {
 		}
 		const capabilityId = BasicCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'Action',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'Action',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'Action',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(OutputSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'Action',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'Action',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(OutputSchema, capabilityResponse.response.value.value)
 	}
 
 	trigger(config: ConfigJson): BasicTrigger {

--- a/src/generated-sdk/capabilities/internal/basicaction/v1/basicaction_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/basicaction/v1/basicaction_sdk_gen.ts
@@ -42,29 +42,29 @@ export class BasicActionCapability {
 		}
 		const capabilityId = BasicActionCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'PerformAction',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'PerformAction',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'PerformAction',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(OutputsSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'PerformAction',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'PerformAction',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(OutputsSchema, capabilityResponse.response.value.value)
 	}
 }

--- a/src/generated-sdk/capabilities/internal/basictrigger/v1/basic_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/basictrigger/v1/basic_sdk_gen.ts
@@ -2,7 +2,7 @@ import { fromBinary, toBinary, fromJson, create } from '@bufbuild/protobuf'
 import { Mode, type CapabilityResponse } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { callCapability } from '@cre/sdk/utils/capabilities/call-capability'
 import { CapabilityError } from '@cre/sdk/utils/capabilities/capability-error'
-import type { Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
+import { type Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
 import { type Any, AnySchema } from '@bufbuild/protobuf/wkt'
 import { getTypeUrl } from '@cre/sdk/utils/typeurl'
 import {

--- a/src/generated-sdk/capabilities/internal/consensus/v1alpha/consensus_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/consensus/v1alpha/consensus_sdk_gen.ts
@@ -46,30 +46,30 @@ export class ConsensusCapability {
 		}
 		const capabilityId = ConsensusCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'Simple',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'Simple',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'Simple',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(ValueSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'Simple',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'Simple',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(ValueSchema, capabilityResponse.response.value.value)
 	}
 
 	async report(input: ReportRequest | ReportRequestJson): Promise<ReportResponse> {
@@ -83,29 +83,29 @@ export class ConsensusCapability {
 		}
 		const capabilityId = ConsensusCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'Report',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'Report',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'Report',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(ReportResponseSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'Report',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'Report',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(ReportResponseSchema, capabilityResponse.response.value.value)
 	}
 }

--- a/src/generated-sdk/capabilities/internal/nodeaction/v1/basicaction_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/nodeaction/v1/basicaction_sdk_gen.ts
@@ -42,29 +42,29 @@ export class BasicActionCapability {
 		}
 		const capabilityId = BasicActionCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'PerformAction',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'PerformAction',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'PerformAction',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(NodeOutputsSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'PerformAction',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'PerformAction',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(NodeOutputsSchema, capabilityResponse.response.value.value)
 	}
 }

--- a/src/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen.ts
@@ -42,29 +42,29 @@ export class ClientCapability {
 		}
 		const capabilityId = ClientCapability.CAPABILITY_ID
 
-		return callCapability({
+		const capabilityResponse = await callCapability({
 			capabilityId,
 			method: 'SendRequest',
 			mode: this.mode,
 			payload,
-		}).then((capabilityResponse: CapabilityResponse) => {
-			if (capabilityResponse.response.case === 'error') {
-				throw new CapabilityError(capabilityResponse.response.value, {
-					capabilityId,
-					method: 'SendRequest',
-					mode: this.mode,
-				})
-			}
-
-			if (capabilityResponse.response.case !== 'payload') {
-				throw new CapabilityError('No payload in response', {
-					capabilityId,
-					method: 'SendRequest',
-					mode: this.mode,
-				})
-			}
-
-			return fromBinary(ResponseSchema, capabilityResponse.response.value.value)
 		})
+
+		if (capabilityResponse.response.case === 'error') {
+			throw new CapabilityError(capabilityResponse.response.value, {
+				capabilityId,
+				method: 'SendRequest',
+				mode: this.mode,
+			})
+		}
+
+		if (capabilityResponse.response.case !== 'payload') {
+			throw new CapabilityError('No payload in response', {
+				capabilityId,
+				method: 'SendRequest',
+				mode: this.mode,
+			})
+		}
+
+		return fromBinary(ResponseSchema, capabilityResponse.response.value.value)
 	}
 }

--- a/src/generated-sdk/capabilities/networking/http/v1alpha/http_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/networking/http/v1alpha/http_sdk_gen.ts
@@ -2,7 +2,7 @@ import { fromBinary, toBinary, fromJson, create } from '@bufbuild/protobuf'
 import { Mode, type CapabilityResponse } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { callCapability } from '@cre/sdk/utils/capabilities/call-capability'
 import { CapabilityError } from '@cre/sdk/utils/capabilities/capability-error'
-import type { Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
+import { type Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
 import { type Any, AnySchema } from '@bufbuild/protobuf/wkt'
 import { getTypeUrl } from '@cre/sdk/utils/typeurl'
 import {

--- a/src/generated-sdk/capabilities/scheduler/cron/v1/cron_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/scheduler/cron/v1/cron_sdk_gen.ts
@@ -2,7 +2,7 @@ import { fromBinary, toBinary, fromJson, create } from '@bufbuild/protobuf'
 import { Mode, type CapabilityResponse } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { callCapability } from '@cre/sdk/utils/capabilities/call-capability'
 import { CapabilityError } from '@cre/sdk/utils/capabilities/capability-error'
-import type { Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
+import { type Trigger } from '@cre/sdk/utils/triggers/trigger-interface'
 import { type Any, AnySchema } from '@bufbuild/protobuf/wkt'
 import { getTypeUrl } from '@cre/sdk/utils/typeurl'
 import {

--- a/src/generated/capabilities/networking/http/v1alpha/trigger_pb.ts
+++ b/src/generated/capabilities/networking/http/v1alpha/trigger_pb.ts
@@ -4,8 +4,10 @@
 
 import type { GenEnum, GenFile, GenMessage, GenService } from '@bufbuild/protobuf/codegenv2'
 import { enumDesc, fileDesc, messageDesc, serviceDesc } from '@bufbuild/protobuf/codegenv2'
+import type { StructJson } from '@bufbuild/protobuf/wkt'
+import { file_google_protobuf_struct } from '@bufbuild/protobuf/wkt'
 import { file_tools_generator_v1alpha_cre_metadata } from '../../../../tools/generator/v1alpha/cre_metadata_pb'
-import type { Message } from '@bufbuild/protobuf'
+import type { JsonObject, Message } from '@bufbuild/protobuf'
 
 /**
  * Describes the file capabilities/networking/http/v1alpha/trigger.proto.
@@ -13,8 +15,8 @@ import type { Message } from '@bufbuild/protobuf'
 export const file_capabilities_networking_http_v1alpha_trigger: GenFile =
 	/*@__PURE__*/
 	fileDesc(
-		'CjJjYXBhYmlsaXRpZXMvbmV0d29ya2luZy9odHRwL3YxYWxwaGEvdHJpZ2dlci5wcm90bxIkY2FwYWJpbGl0aWVzLm5ldHdvcmtpbmcuaHR0cC52MWFscGhhIlYKBkNvbmZpZxJMCg9hdXRob3JpemVkX2tleXMYASADKAsyMy5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGEuQXV0aG9yaXplZEtleSJaCgdQYXlsb2FkEg0KBWlucHV0GAEgASgMEkAKA2tleRgCIAEoCzIzLmNhcGFiaWxpdGllcy5uZXR3b3JraW5nLmh0dHAudjFhbHBoYS5BdXRob3JpemVkS2V5ImAKDUF1dGhvcml6ZWRLZXkSOwoEdHlwZRgBIAEoDjItLmNhcGFiaWxpdGllcy5uZXR3b3JraW5nLmh0dHAudjFhbHBoYS5LZXlUeXBlEhIKCnB1YmxpY19rZXkYAiABKAkqOwoHS2V5VHlwZRIYChRLRVlfVFlQRV9VTlNQRUNJRklFRBAAEhYKEktFWV9UWVBFX0VDRFNBX0VWTRABMpIBCgRIVFRQEmgKB1RyaWdnZXISLC5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGEuQ29uZmlnGi0uY2FwYWJpbGl0aWVzLm5ldHdvcmtpbmcuaHR0cC52MWFscGhhLlBheWxvYWQwARoggrUYHAgBEhhodHRwLXRyaWdnZXJAMS4wLjAtYWxwaGFC6wEKKGNvbS5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGFCDFRyaWdnZXJQcm90b1ABogIDQ05IqgIkQ2FwYWJpbGl0aWVzLk5ldHdvcmtpbmcuSHR0cC5WMWFscGhhygIkQ2FwYWJpbGl0aWVzXE5ldHdvcmtpbmdcSHR0cFxWMWFscGhh4gIwQ2FwYWJpbGl0aWVzXE5ldHdvcmtpbmdcSHR0cFxWMWFscGhhXEdQQk1ldGFkYXRh6gInQ2FwYWJpbGl0aWVzOjpOZXR3b3JraW5nOjpIdHRwOjpWMWFscGhhYgZwcm90bzM',
-		[file_tools_generator_v1alpha_cre_metadata],
+		'CjJjYXBhYmlsaXRpZXMvbmV0d29ya2luZy9odHRwL3YxYWxwaGEvdHJpZ2dlci5wcm90bxIkY2FwYWJpbGl0aWVzLm5ldHdvcmtpbmcuaHR0cC52MWFscGhhIlYKBkNvbmZpZxJMCg9hdXRob3JpemVkX2tleXMYASADKAsyMy5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGEuQXV0aG9yaXplZEtleSJzCgdQYXlsb2FkEiYKBWlucHV0GAEgASgLMhcuZ29vZ2xlLnByb3RvYnVmLlN0cnVjdBJACgNrZXkYAiABKAsyMy5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGEuQXV0aG9yaXplZEtleSJgCg1BdXRob3JpemVkS2V5EjsKBHR5cGUYASABKA4yLS5jYXBhYmlsaXRpZXMubmV0d29ya2luZy5odHRwLnYxYWxwaGEuS2V5VHlwZRISCgpwdWJsaWNfa2V5GAIgASgJKjsKB0tleVR5cGUSGAoUS0VZX1RZUEVfVU5TUEVDSUZJRUQQABIWChJLRVlfVFlQRV9FQ0RTQV9FVk0QATKSAQoESFRUUBJoCgdUcmlnZ2VyEiwuY2FwYWJpbGl0aWVzLm5ldHdvcmtpbmcuaHR0cC52MWFscGhhLkNvbmZpZxotLmNhcGFiaWxpdGllcy5uZXR3b3JraW5nLmh0dHAudjFhbHBoYS5QYXlsb2FkMAEaIIK1GBwIARIYaHR0cC10cmlnZ2VyQDEuMC4wLWFscGhhQusBCihjb20uY2FwYWJpbGl0aWVzLm5ldHdvcmtpbmcuaHR0cC52MWFscGhhQgxUcmlnZ2VyUHJvdG9QAaICA0NOSKoCJENhcGFiaWxpdGllcy5OZXR3b3JraW5nLkh0dHAuVjFhbHBoYcoCJENhcGFiaWxpdGllc1xOZXR3b3JraW5nXEh0dHBcVjFhbHBoYeICMENhcGFiaWxpdGllc1xOZXR3b3JraW5nXEh0dHBcVjFhbHBoYVxHUEJNZXRhZGF0YeoCJ0NhcGFiaWxpdGllczo6TmV0d29ya2luZzo6SHR0cDo6VjFhbHBoYWIGcHJvdG8z',
+		[file_google_protobuf_struct, file_tools_generator_v1alpha_cre_metadata],
 	)
 
 /**
@@ -54,11 +56,11 @@ export const ConfigSchema: GenMessage<Config, { jsonType: ConfigJson }> =
  */
 export type Payload = Message<'capabilities.networking.http.v1alpha.Payload'> & {
 	/**
-	 * JSON input in the HTTP trigger request (as bytes)
+	 * JSON input in the HTTP trigger request
 	 *
-	 * @generated from field: bytes input = 1;
+	 * @generated from field: google.protobuf.Struct input = 1;
 	 */
-	input: Uint8Array
+	input?: JsonObject
 
 	/**
 	 * Key used to sign the HTTP trigger request
@@ -73,11 +75,11 @@ export type Payload = Message<'capabilities.networking.http.v1alpha.Payload'> & 
  */
 export type PayloadJson = {
 	/**
-	 * JSON input in the HTTP trigger request (as bytes)
+	 * JSON input in the HTTP trigger request
 	 *
-	 * @generated from field: bytes input = 1;
+	 * @generated from field: google.protobuf.Struct input = 1;
 	 */
-	input?: string
+	input?: StructJson
 
 	/**
 	 * Key used to sign the HTTP trigger request

--- a/src/generator/generate-action.ts
+++ b/src/generator/generate-action.ts
@@ -32,30 +32,30 @@ export function generateActionMethod(
       typeUrl: getTypeUrl(${method.input.name}Schema),
       value: toBinary(${method.input.name}Schema, value),
     };${capabilityIdLogic}
-    
-    return callCapability({
+
+    const capabilityResponse = await callCapability({
       capabilityId,
       method: "${method.name}",
       mode: this.mode,
-      payload,
-    }).then((capabilityResponse: CapabilityResponse) => {
-      if (capabilityResponse.response.case === "error") {
-        throw new CapabilityError(capabilityResponse.response.value, {
-          capabilityId,
-          method: "${method.name}",
-          mode: this.mode,
-        });
-      }
-
-      if (capabilityResponse.response.case !== "payload") {
-        throw new CapabilityError("No payload in response", {
-          capabilityId,
-          method: "${method.name}",
-          mode: this.mode,
-        });
-      }
-
-      return fromBinary(${method.output.name}Schema, capabilityResponse.response.value.value);
+      payload
     });
+
+    if (capabilityResponse.response.case === 'error') {
+      throw new CapabilityError(capabilityResponse.response.value, {
+        capabilityId,
+        method: "${method.name}",
+        mode: this.mode,
+      })
+    }
+
+    if (capabilityResponse.response.case !== 'payload') {
+      throw new CapabilityError('No payload in response', {
+        capabilityId,
+        method: "${method.name}",
+        mode: this.mode,
+      })
+    }
+
+    return fromBinary(${method.output.name}Schema, capabilityResponse.response.value.value)
   }`
 }


### PR DESCRIPTION
I'm currently coming up with an explaination as to why using await vs `.then` makes everything suddenly work. It could be an issue with throwing errors in the then callback, but I'll try to pin down the actual issue. 

It looks like this is where calling `callCabability.then` fails for some reason:

https://github.com/smartcontractkit/cre-sdk-typescript/blob/main/src/sdk/utils/lazy-promise.ts#L44

I get stuck at `this.factory()` and it never progresses. It doesn't throw an error either. I'm still not sure why using `await` fixes the issue.