### PR TITLE
feat(DAPP-7422): move from lazy promise to async result

### DIFF
--- a/src/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen.ts
@@ -100,9 +100,9 @@ export class ClientCapability {
 		private readonly chainSelector?: bigint,
 	) {}
 
-	async callContract(
-		input: CallContractRequest | CallContractRequestJson,
-	): Promise<CallContractReply> {
+	callContract(input: CallContractRequest | CallContractRequestJson): {
+		result: () => Promise<CallContractReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as CallContractRequest)
@@ -116,33 +116,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'CallContract',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'CallContract',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'CallContract',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'CallContract',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(CallContractReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'CallContract',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(CallContractReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async filterLogs(input: FilterLogsRequest | FilterLogsRequestJson): Promise<FilterLogsReply> {
+	filterLogs(input: FilterLogsRequest | FilterLogsRequestJson): {
+		result: () => Promise<FilterLogsReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as FilterLogsRequest)
@@ -156,33 +164,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'FilterLogs',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'FilterLogs',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'FilterLogs',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'FilterLogs',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(FilterLogsReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'FilterLogs',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(FilterLogsReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async balanceAt(input: BalanceAtRequest | BalanceAtRequestJson): Promise<BalanceAtReply> {
+	balanceAt(input: BalanceAtRequest | BalanceAtRequestJson): {
+		result: () => Promise<BalanceAtReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as BalanceAtRequest)
@@ -196,33 +212,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'BalanceAt',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'BalanceAt',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'BalanceAt',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'BalanceAt',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(BalanceAtReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'BalanceAt',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(BalanceAtReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async estimateGas(input: EstimateGasRequest | EstimateGasRequestJson): Promise<EstimateGasReply> {
+	estimateGas(input: EstimateGasRequest | EstimateGasRequestJson): {
+		result: () => Promise<EstimateGasReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as EstimateGasRequest)
@@ -236,35 +260,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'EstimateGas',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'EstimateGas',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'EstimateGas',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'EstimateGas',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(EstimateGasReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'EstimateGas',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(EstimateGasReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async getTransactionByHash(
-		input: GetTransactionByHashRequest | GetTransactionByHashRequestJson,
-	): Promise<GetTransactionByHashReply> {
+	getTransactionByHash(input: GetTransactionByHashRequest | GetTransactionByHashRequestJson): {
+		result: () => Promise<GetTransactionByHashReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as GetTransactionByHashRequest)
@@ -278,35 +308,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'GetTransactionByHash',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'GetTransactionByHash',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'GetTransactionByHash',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'GetTransactionByHash',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(GetTransactionByHashReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'GetTransactionByHash',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(GetTransactionByHashReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async getTransactionReceipt(
-		input: GetTransactionReceiptRequest | GetTransactionReceiptRequestJson,
-	): Promise<GetTransactionReceiptReply> {
+	getTransactionReceipt(input: GetTransactionReceiptRequest | GetTransactionReceiptRequestJson): {
+		result: () => Promise<GetTransactionReceiptReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as GetTransactionReceiptRequest)
@@ -320,35 +356,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'GetTransactionReceipt',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'GetTransactionReceipt',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'GetTransactionReceipt',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'GetTransactionReceipt',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(GetTransactionReceiptReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'GetTransactionReceipt',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(GetTransactionReceiptReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async headerByNumber(
-		input: HeaderByNumberRequest | HeaderByNumberRequestJson,
-	): Promise<HeaderByNumberReply> {
+	headerByNumber(input: HeaderByNumberRequest | HeaderByNumberRequestJson): {
+		result: () => Promise<HeaderByNumberReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as HeaderByNumberRequest)
@@ -362,35 +404,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'HeaderByNumber',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'HeaderByNumber',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'HeaderByNumber',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'HeaderByNumber',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(HeaderByNumberReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'HeaderByNumber',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(HeaderByNumberReplySchema, response.value.value)
+			},
+		}
 	}
 
-	async registerLogTracking(
-		input: RegisterLogTrackingRequest | RegisterLogTrackingRequestJson,
-	): Promise<Empty> {
+	registerLogTracking(input: RegisterLogTrackingRequest | RegisterLogTrackingRequestJson): {
+		result: () => Promise<Empty>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as RegisterLogTrackingRequest)
@@ -404,35 +452,41 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'RegisterLogTracking',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'RegisterLogTracking',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'RegisterLogTracking',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'RegisterLogTracking',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(EmptySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'RegisterLogTracking',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(EmptySchema, response.value.value)
+			},
+		}
 	}
 
-	async unregisterLogTracking(
-		input: UnregisterLogTrackingRequest | UnregisterLogTrackingRequestJson,
-	): Promise<Empty> {
+	unregisterLogTracking(input: UnregisterLogTrackingRequest | UnregisterLogTrackingRequestJson): {
+		result: () => Promise<Empty>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as UnregisterLogTrackingRequest)
@@ -446,37 +500,45 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'UnregisterLogTracking',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'UnregisterLogTracking',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'UnregisterLogTracking',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'UnregisterLogTracking',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(EmptySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'UnregisterLogTracking',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(EmptySchema, response.value.value)
+			},
+		}
 	}
 
 	logTrigger(config: FilterLogTriggerRequestJson): ClientLogTrigger {
 		return new ClientLogTrigger(this.mode, config, ClientCapability.CAPABILITY_ID, 'LogTrigger')
 	}
 
-	async writeReport(input: WriteReportRequest | WriteReportRequestJson): Promise<WriteReportReply> {
+	writeReport(input: WriteReportRequest | WriteReportRequestJson): {
+		result: () => Promise<WriteReportReply>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as WriteReportRequest)
@@ -490,30 +552,36 @@ export class ClientCapability {
 			? `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.chainSelector}@${ClientCapability.CAPABILITY_VERSION}`
 			: ClientCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'WriteReport',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'WriteReport',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'WriteReport',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'WriteReport',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(WriteReportReplySchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'WriteReport',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(WriteReportReplySchema, response.value.value)
+			},
+		}
 	}
 }
 

--- a/src/generated-sdk/capabilities/internal/consensus/v1alpha/consensus_sdk_gen.ts
+++ b/src/generated-sdk/capabilities/internal/consensus/v1alpha/consensus_sdk_gen.ts
@@ -35,7 +35,9 @@ export class ConsensusCapability {
 
 	constructor(private readonly mode: Mode = ConsensusCapability.DEFAULT_MODE) {}
 
-	async simple(input: SimpleConsensusInputs | SimpleConsensusInputsJson): Promise<Value> {
+	simple(input: SimpleConsensusInputs | SimpleConsensusInputsJson): {
+		result: () => Promise<Value>
+	} {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as SimpleConsensusInputs)
@@ -46,33 +48,39 @@ export class ConsensusCapability {
 		}
 		const capabilityId = ConsensusCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'Simple',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'Simple',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'Simple',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'Simple',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(ValueSchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'Simple',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(ValueSchema, response.value.value)
+			},
+		}
 	}
 
-	async report(input: ReportRequest | ReportRequestJson): Promise<ReportResponse> {
+	report(input: ReportRequest | ReportRequestJson): { result: () => Promise<ReportResponse> } {
 		// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
 		const value = (input as any).$typeName
 			? (input as ReportRequest)
@@ -83,29 +91,35 @@ export class ConsensusCapability {
 		}
 		const capabilityId = ConsensusCapability.CAPABILITY_ID
 
-		const capabilityResponse = await callCapability({
+		const capabilityResponse = callCapability({
 			capabilityId,
 			method: 'Report',
 			mode: this.mode,
 			payload,
 		})
 
-		if (capabilityResponse.response.case === 'error') {
-			throw new CapabilityError(capabilityResponse.response.value, {
-				capabilityId,
-				method: 'Report',
-				mode: this.mode,
-			})
-		}
+		return {
+			result: async () => {
+				const { response } = await capabilityResponse.result()
 
-		if (capabilityResponse.response.case !== 'payload') {
-			throw new CapabilityError('No payload in response', {
-				capabilityId,
-				method: 'Report',
-				mode: this.mode,
-			})
-		}
+				if (response.case === 'error') {
+					throw new CapabilityError(response.value, {
+						capabilityId,
+						method: 'Report',
+						mode: this.mode,
+					})
+				}
 
-		return fromBinary(ReportResponseSchema, capabilityResponse.response.value.value)
+				if (response.case !== 'payload') {
+					throw new CapabilityError('No payload in response', {
+						capabilityId,
+						method: 'Report',
+						mode: this.mode,
+					})
+				}
+
+				return fromBinary(ReportResponseSchema, response.value.value)
+			},
+		}
 	}
 }

--- a/src/sdk/runtime/run-in-node-mode.test.ts
+++ b/src/sdk/runtime/run-in-node-mode.test.ts
@@ -37,7 +37,7 @@ describe('runInNodeMode', () => {
 		// spy on consensus.simple
 		const origSimple = ConsensusCapability.prototype.simple
 		ConsensusCapability.prototype.simple = mock(
-			async (inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
+			(inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
 				calls.push('CONSENSUS_SIMPLE')
 
 				// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
@@ -55,7 +55,7 @@ describe('runInNodeMode', () => {
 				})
 				expect(castedInputs.descriptors).toEqual(expectedDescriptor)
 
-				return Value.from(anyResult).proto()
+				return { result: async () => Value.from(anyResult).proto() }
 			},
 		)
 
@@ -81,7 +81,7 @@ describe('runInNodeMode', () => {
 		// spy on consensus.simple
 		const origSimple = ConsensusCapability.prototype.simple
 		ConsensusCapability.prototype.simple = mock(
-			async (inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
+			(inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
 				calls.push('CONSENSUS_SIMPLE')
 
 				// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
@@ -99,7 +99,7 @@ describe('runInNodeMode', () => {
 				})
 				expect(castedInputs.descriptors).toEqual(expectedDescriptor)
 
-				return Value.from(anyResult).proto()
+				return { result: async () => Value.from(anyResult).proto() }
 			},
 		)
 
@@ -123,7 +123,7 @@ describe('runInNodeMode', () => {
 		// spy on consensus.simple
 		const origSimple = ConsensusCapability.prototype.simple
 		ConsensusCapability.prototype.simple = mock(
-			async (inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
+			(inputs: SimpleConsensusInputs | SimpleConsensusInputsJson) => {
 				calls.push('CONSENSUS_SIMPLE')
 
 				// biome-ignore lint/suspicious/noExplicitAny: Needed for runtime type checking of protocol buffer messages
@@ -148,7 +148,7 @@ describe('runInNodeMode', () => {
 		expect(async () => {
 			await runInNodeMode(async (_: NodeRuntime) => {
 				const ba = new BasicActionCapability()
-				const result = await ba.performAction({ inputThing: true })
+				const result = await ba.performAction({ inputThing: true }).result()
 				return result.adaptedThing
 			}, consensusIdenticalAggregation())()
 		}).toThrow(/.*cannot use Runtime inside RunInNodeMode.*/)

--- a/src/sdk/runtime/run-in-node-mode.ts
+++ b/src/sdk/runtime/run-in-node-mode.ts
@@ -1,4 +1,4 @@
-import { create, toJson } from '@bufbuild/protobuf'
+import { create } from '@bufbuild/protobuf'
 import { Mode, SimpleConsensusInputsSchema } from '@cre/generated/sdk/v1alpha/sdk_pb'
 import { ConsensusCapability } from '@cre/generated-sdk/capabilities/internal/consensus/v1alpha/consensus_sdk_gen'
 import { runtime, type NodeRuntime } from '@cre/sdk/runtime/runtime'
@@ -47,7 +47,7 @@ export function runInNodeMode<TArgs extends any[], TOutput>(
 		}
 
 		const consensus = new ConsensusCapability()
-		const result = await consensus.simple(consensusInput)
+		const result = await consensus.simple(consensusInput).result()
 		const wrappedValue = Value.wrap(result)
 
 		return unwrapOptions

--- a/src/sdk/utils/capabilities/http/fetch.ts
+++ b/src/sdk/utils/capabilities/http/fetch.ts
@@ -71,7 +71,7 @@ export const creFetch = async (input: CreFetchRequest) => {
 	const validatedInput = creFetchRequestSchema.parse(input)
 	const httpClient = new cre.capabilities.HTTPClient()
 
-	const resp = await httpClient.sendRequest(validatedInput)
+	const resp = await httpClient.sendRequest(validatedInput).result()
 
 	return {
 		statusCode: resp.statusCode,

--- a/src/workflows/on-chain-write/on-chain-write.ts
+++ b/src/workflows/on-chain-write/on-chain-write.ts
@@ -59,17 +59,19 @@ const onCronTrigger = async (config: Config, runtime: Runtime): Promise<void> =>
 		functionName: 'get',
 	})
 
-	const contractCall = await evmClient.callContract({
-		call: {
-			from: hexToBase64(zeroAddress),
-			to: hexToBase64(evmConfig.storageAddress),
-			data: hexToBase64(callData),
-		},
-		blockNumber: {
-			absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-			sign: '-1', // negative for finalized
-		},
-	})
+	const contractCall = await evmClient
+		.callContract({
+			call: {
+				from: hexToBase64(zeroAddress),
+				to: hexToBase64(evmConfig.storageAddress),
+				data: hexToBase64(callData),
+			},
+			blockNumber: {
+				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
+				sign: '-1', // negative for finalized
+			},
+		})
+		.result()
 
 	// Decode the result
 	const onchainValue = decodeFunctionResult({
@@ -104,17 +106,19 @@ const onCronTrigger = async (config: Config, runtime: Runtime): Promise<void> =>
 	runtime.logger.log('Dry running call to ensure the value is not anomalous...')
 
 	// dry run the call to ensure the value is not anomalous
-	const dryRunCall = await evmClient.callContract({
-		call: {
-			from: hexToBase64(zeroAddress),
-			to: hexToBase64(evmConfig.calculatorConsumerAddress),
-			data: hexToBase64(dryRunCallData),
-		},
-		blockNumber: {
-			absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-			sign: '-1', // negative for finalized
-		},
-	})
+	const dryRunCall = await evmClient
+		.callContract({
+			call: {
+				from: hexToBase64(zeroAddress),
+				to: hexToBase64(evmConfig.calculatorConsumerAddress),
+				data: hexToBase64(dryRunCallData),
+			},
+			blockNumber: {
+				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
+				sign: '-1', // negative for finalized
+			},
+		})
+		.result()
 
 	const dryRunResponse = decodeFunctionResult({
 		abi: CALCULATOR_CONSUMER_ABI,
@@ -136,12 +140,14 @@ const onCronTrigger = async (config: Config, runtime: Runtime): Promise<void> =>
 		args: [toHex('0x'), dryRunCallData],
 	})
 
-	const resp = await evmClient.writeReport({
-		receiver: evmConfig.calculatorConsumerAddress,
-		report: {
-			rawReport: writeCallData,
-		},
-	})
+	const resp = await evmClient
+		.writeReport({
+			receiver: evmConfig.calculatorConsumerAddress,
+			report: {
+				rawReport: writeCallData,
+			},
+		})
+		.result()
 
 	const txHash = resp.txHash
 

--- a/src/workflows/on-chain/on-chain.ts
+++ b/src/workflows/on-chain/on-chain.ts
@@ -59,17 +59,19 @@ const onCronTrigger = async (config: Config, runtime: Runtime): Promise<void> =>
 		functionName: 'get',
 	})
 
-	const contractCall = await evmClient.callContract({
-		call: {
-			from: hexToBase64(zeroAddress),
-			to: hexToBase64(evmConfig.storageAddress),
-			data: hexToBase64(callData),
-		},
-		blockNumber: {
-			absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-			sign: '-1', // negative for finalized
-		},
-	})
+	const contractCall = await evmClient
+		.callContract({
+			call: {
+				from: hexToBase64(zeroAddress),
+				to: hexToBase64(evmConfig.storageAddress),
+				data: hexToBase64(callData),
+			},
+			blockNumber: {
+				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
+				sign: '-1', // negative for finalized
+			},
+		})
+		.result()
 
 	// Decode the result
 	const onchainValue = decodeFunctionResult({

--- a/src/workflows/standard_tests/capability_calls_are_async/test.ts
+++ b/src/workflows/standard_tests/capability_calls_are_async/test.ts
@@ -13,9 +13,9 @@ const asyncCalls = async () => {
 	const p1 = basicAction.performAction(input1)
 	const p2 = basicAction.performAction(input2)
 
-	// We await them in the reverse order.
-	const r2 = await p2
-	const r1 = await p1
+	// We get results in the reverse order.
+	const r2 = await p2.result()
+	const r1 = await p1.result()
 
 	cre.sendResponseValue(Value.from(`${r1.adaptedThing}${r2.adaptedThing}`))
 }

--- a/src/workflows/standard_tests/mode_switch/don_runtime_in_node_mode/test.ts
+++ b/src/workflows/standard_tests/mode_switch/don_runtime_in_node_mode/test.ts
@@ -11,7 +11,7 @@ const handler = async (_config: Config) => {
 	try {
 		await runInNodeMode(async () => {
 			const basicCap = new BasicActionCapability()
-			return (await basicCap.performAction({ inputThing: true })).adaptedThing
+			return (await basicCap.performAction({ inputThing: true }).result()).adaptedThing
 		}, consensusIdenticalAggregation())()
 	} catch (e) {
 		cre.sendError(e as Error)

--- a/src/workflows/standard_tests/mode_switch/node_runtime_in_don_mode/test.ts
+++ b/src/workflows/standard_tests/mode_switch/node_runtime_in_don_mode/test.ts
@@ -18,7 +18,7 @@ const handler = async () => {
 		// We shoudl be using node runtime here in future...
 		const _ = nrt
 		const nodeActionCapability = new NodeActionCapability()
-		await nodeActionCapability.performAction({ inputThing: true })
+		await nodeActionCapability.performAction({ inputThing: true }).result()
 	} catch (e) {
 		console.log('error', e)
 		if (e instanceof NodeModeError) {

--- a/src/workflows/standard_tests/mode_switch/successful_mode_switch/test.ts
+++ b/src/workflows/standard_tests/mode_switch/successful_mode_switch/test.ts
@@ -15,16 +15,18 @@ class Output {
 const handler = async (_config: Config, runtime: Runtime) => {
 	const donInput = { inputThing: true }
 	const basicActionCapability = new BasicActionCapability()
-	const donResponse = await basicActionCapability.performAction(donInput)
+	const donResponse = await basicActionCapability.performAction(donInput).result()
 	runtime.now()
 
 	const consensusOutput = await cre.runInNodeMode(
 		async (nodeRuntime: NodeRuntime): Promise<Output> => {
 			nodeRuntime.now()
 			const nodeActionCapability = new NodeActionCapability()
-			const nodeResponse = await nodeActionCapability.performAction({
-				inputThing: true,
-			})
+			const nodeResponse = await nodeActionCapability
+				.performAction({
+					inputThing: true,
+				})
+				.result()
 
 			return new Output(new Int64(nodeResponse.outputThing))
 		},

--- a/src/workflows/standard_tests/random/test.ts
+++ b/src/workflows/standard_tests/random/test.ts
@@ -20,9 +20,11 @@ const randHandler = async (_config: Config, runtime: Runtime) => {
 			const nodeRandomNumber = nodeRuntime.getRand().Uint64()
 
 			const nodeActionCapability = new NodeActionCapability()
-			const nodeResponse = await nodeActionCapability.performAction({
-				inputThing: true,
-			})
+			const nodeResponse = await nodeActionCapability
+				.performAction({
+					inputThing: true,
+				})
+				.result()
 
 			if (nodeResponse.outputThing < 100) {
 				log(`***${nodeRandomNumber.toString()}`)


### PR DESCRIPTION
- Proposal for removing reliance on LazyPromise
- Separating the initial capability call and the result call defers the blocking call until the result function is called/awaited
- Follows common promise patterns and doesn't rely on user avoiding calling await or then
- Below are a few other possible comparisons

```
// A. This is what is proposed in this PR, a single await for the result
const p1 = basicAction.performAction(input1)
const p2 = basicAction.performAction(input2)

const r2 = await p2.result()
const r1 = await p1.result()

// Inline awaits is simple
const inline = await basicAction.performAction(input1).result();

```

```
// B. We could also only promise at the action level, which makes it obvious that the result call is synchronous/blocking
const p1 = await basicAction.performAction(input1)
const p2 = await basicAction.performAction(input2)

const r2 = p2.result()
const r1 = p1.result()

// Inline await is still simple
const inline = await basicAction.performAction(input1).result();
```

```
// C. We could potentially require awaiting at both levels, like in fetch
// This is arguably the most technically correct pattern, but it is annoying to work with inline/shorthand
const p1 = await basicAction.performAction(input1)
const p2 = await basicAction.performAction(input2)

const r2 = await p2.result()
const r1 = await p1.result()

// Inline awaits are more cumbersome, but this is also how fetch looks
const inline = await (await basicAction.performAction(input1)).result();
```

```
// D.  Lastly, we could not use promises at all since neither of these function calls actually benefit from promises
const p1 = basicAction.performAction(input1)
const p2 = basicAction.performAction(input2)

const r2 = p2.result()
const r1 = p1.result()

// Inline requires no await
const inline = basicAction.performAction(input1).result();
```

In each of the cases above, the code never blocks until calling `.result()` on an action. This makes it much more intuitive as to what is happening than the magic with a LazyPromise. In order I prefer A, D, C, B, but I'd like to see what @ernest-nowacki and @ryannelsonsmartcontract think about these proposed patterns. 