### PR TITLE
fix: use output filename for js build

### DIFF
--- a/packages/cre-sdk/scripts/src/compile-to-js.ts
+++ b/packages/cre-sdk/scripts/src/compile-to-js.ts
@@ -38,6 +38,7 @@ export const main = async (tsFilePath?: string, outputFilePath?: string) => {
 		outdir: path.dirname(resolvedOutput),
 		target: 'node',
 		format: 'esm',
+		naming: path.basename(resolvedOutput),
 	})
 
 	// The file Bun will emit before bundling


### PR DESCRIPTION
Just need to update the build to use the output name instead of the input name the the produced JS file. 