### PR TITLE
Add blockchain helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/cre-sdk": {
       "name": "@chainlink/cre-sdk",
-      "version": "0.0.1",
+      "version": "0.0.3-alpha",
       "bin": {
         "cre-compile": "bin/cre-compile.ts",
       },
@@ -37,14 +37,15 @@
     },
     "packages/cre-sdk-examples": {
       "name": "@chainlink/cre-sdk-examples",
-      "version": "0.0.1",
+      "version": "0.0.3-alpha",
       "dependencies": {
+        "@bufbuild/protobuf": "2.6.3",
         "@chainlink/cre-sdk": "workspace:*",
       },
     },
     "packages/cre-sdk-javy-plugin": {
       "name": "@chainlink/cre-sdk-javy-plugin",
-      "version": "0.0.1",
+      "version": "0.0.3-alpha",
       "bin": {
         "cre-setup": "bin/setup.ts",
         "cre-compile-workflow": "bin/compile-workflow.ts",

--- a/packages/cre-sdk-examples/package.json
+++ b/packages/cre-sdk-examples/package.json
@@ -14,6 +14,7 @@
 		"typecheck": "tsc"
 	},
 	"dependencies": {
+		"@bufbuild/protobuf": "2.6.3",
 		"@chainlink/cre-sdk": "workspace:*"
 	},
 	"engines": {

--- a/packages/cre-sdk-examples/src/workflows/on-chain-write/index.ts
+++ b/packages/cre-sdk-examples/src/workflows/on-chain-write/index.ts
@@ -2,15 +2,16 @@ import {
 	bytesToHex,
 	consensusMedianAggregation,
 	cre,
+	encodeCallMsg,
 	getNetwork,
 	type HTTPSendRequester,
-	hexToBase64,
+	LAST_FINALIZED_BLOCK_NUMBER,
 	ok,
 	Runner,
 	type Runtime,
 	text,
 } from '@chainlink/cre-sdk'
-import { decodeFunctionResult, encodeFunctionData, toHex, zeroAddress } from 'viem'
+import { type Address, decodeFunctionResult, encodeFunctionData, toHex, zeroAddress } from 'viem'
 import { z } from 'zod'
 import { CALCULATOR_CONSUMER_ABI, STORAGE_ABI } from './abi'
 
@@ -77,15 +78,12 @@ const onCronTrigger = (runtime: Runtime<Config>) => {
 
 	const contractCall = evmClient
 		.callContract(runtime, {
-			call: {
-				from: hexToBase64(zeroAddress),
-				to: hexToBase64(evmConfig.storageAddress),
-				data: hexToBase64(callData),
-			},
-			blockNumber: {
-				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-				sign: '-1', // negative for finalized
-			},
+			call: encodeCallMsg({
+				from: zeroAddress,
+				to: evmConfig.storageAddress as Address,
+				data: callData,
+			}),
+			blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 		})
 		.result()
 
@@ -124,15 +122,12 @@ const onCronTrigger = (runtime: Runtime<Config>) => {
 	// dry run the call to ensure the value is not anomalous
 	const dryRunCall = evmClient
 		.callContract(runtime, {
-			call: {
-				from: hexToBase64(zeroAddress),
-				to: hexToBase64(evmConfig.calculatorConsumerAddress),
-				data: hexToBase64(dryRunCallData),
-			},
-			blockNumber: {
-				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-				sign: '-1', // negative for finalized
-			},
+			call: encodeCallMsg({
+				from: zeroAddress,
+				to: evmConfig.calculatorConsumerAddress as Address,
+				data: dryRunCallData,
+			}),
+			blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 		})
 		.result()
 

--- a/packages/cre-sdk-examples/src/workflows/on-chain/index.ts
+++ b/packages/cre-sdk-examples/src/workflows/on-chain/index.ts
@@ -2,15 +2,16 @@ import {
 	bytesToHex,
 	consensusMedianAggregation,
 	cre,
+	encodeCallMsg,
 	getNetwork,
 	type HTTPSendRequester,
-	hexToBase64,
+	LAST_FINALIZED_BLOCK_NUMBER,
 	ok,
 	Runner,
 	type Runtime,
 	text,
 } from '@chainlink/cre-sdk'
-import { decodeFunctionResult, encodeFunctionData, zeroAddress } from 'viem'
+import { type Address, decodeFunctionResult, encodeFunctionData, zeroAddress } from 'viem'
 import { z } from 'zod'
 
 import { STORAGE_ABI } from './abi'
@@ -76,15 +77,12 @@ const onCronTrigger = (runtime: Runtime<Config>) => {
 
 	const contractCall = evmClient
 		.callContract(runtime, {
-			call: {
-				from: hexToBase64(zeroAddress),
-				to: hexToBase64(evmConfig.storageAddress),
-				data: hexToBase64(callData),
-			},
-			blockNumber: {
-				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-				sign: '-1', // negative for finalized
-			},
+			call: encodeCallMsg({
+				from: zeroAddress,
+				to: evmConfig.storageAddress as Address,
+				data: callData,
+			}),
+			blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 		})
 		.result()
 

--- a/packages/cre-sdk-examples/src/workflows/proof-of-reserve/index.ts
+++ b/packages/cre-sdk-examples/src/workflows/proof-of-reserve/index.ts
@@ -4,10 +4,12 @@ import {
 	type CronPayload,
 	cre,
 	type EVMLog,
+	encodeCallMsg,
 	getNetwork,
 	type HTTPPayload,
 	type HTTPSendRequester,
 	hexToBase64,
+	LAST_FINALIZED_BLOCK_NUMBER,
 	median,
 	Runner,
 	type Runtime,
@@ -97,15 +99,12 @@ const fetchNativeTokenBalance = (
 
 	const contractCall = evmClient
 		.callContract(runtime, {
-			call: {
-				from: hexToBase64(zeroAddress),
-				to: hexToBase64(evmConfig.balanceReaderAddress),
-				data: hexToBase64(callData),
-			},
-			blockNumber: {
-				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-				sign: '-1', // negative for finalized
-			},
+			call: encodeCallMsg({
+				from: zeroAddress,
+				to: evmConfig.balanceReaderAddress as Address,
+				data: callData,
+			}),
+			blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 		})
 		.result()
 
@@ -148,15 +147,12 @@ const getTotalSupply = (runtime: Runtime<Config>): bigint => {
 
 		const contractCall = evmClient
 			.callContract(runtime, {
-				call: {
-					from: hexToBase64(zeroAddress),
-					to: hexToBase64(evmConfig.tokenAddress),
-					data: hexToBase64(callData),
-				},
-				blockNumber: {
-					absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-					sign: '-1', // negative for finalized
-				},
+				call: encodeCallMsg({
+					from: zeroAddress,
+					to: evmConfig.tokenAddress as Address,
+					data: callData,
+				}),
+				blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 			})
 			.result()
 
@@ -316,15 +312,12 @@ const getLastMessage = (
 
 	const contractCall = evmClient
 		.callContract(runtime, {
-			call: {
-				from: hexToBase64(zeroAddress),
-				to: hexToBase64(evmConfig.messageEmitterAddress),
-				data: hexToBase64(callData),
-			},
-			blockNumber: {
-				absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
-				sign: '-1', // negative for finalized
-			},
+			call: encodeCallMsg({
+				from: zeroAddress,
+				to: evmConfig.messageEmitterAddress as Address,
+				data: callData,
+			}),
+			blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
 		})
 		.result()
 

--- a/packages/cre-sdk/src/index.ts
+++ b/packages/cre-sdk/src/index.ts
@@ -4,5 +4,5 @@ export * from './sdk'
 export * from './sdk/runtime'
 export * from './sdk/utils'
 // Export HTTP response helpers
-export * from './sdk/utils/http-helpers'
+export * from './sdk/utils/capabilities/http/http-helpers'
 export * from './sdk/wasm'

--- a/packages/cre-sdk/src/sdk/impl/runtime-impl.ts
+++ b/packages/cre-sdk/src/sdk/impl/runtime-impl.ts
@@ -68,8 +68,11 @@ export class BaseRuntimeImpl<C> implements BaseRuntime<C> {
 
 		const anyPayload = anyPack(inputSchema, payload)
 		const callbackId = this.nextCallId
-		if (this.mode === Mode.DON) this.nextCallId++
-		else this.nextCallId--
+		if (this.mode === Mode.DON) {
+			this.nextCallId++
+		} else {
+			this.nextCallId--
+		}
 
 		const req = create(CapabilityRequestSchema, {
 			id: capabilityId,

--- a/packages/cre-sdk/src/sdk/utils/capabilities/blockchain/blockchain-helpers.ts
+++ b/packages/cre-sdk/src/sdk/utils/capabilities/blockchain/blockchain-helpers.ts
@@ -1,0 +1,59 @@
+import type { CallMsgJson } from '@cre/generated/capabilities/blockchain/evm/v1alpha/client_pb'
+import { hexToBase64 } from '@cre/sdk/utils/hex-utils'
+import type { Address, Hex } from 'viem'
+
+/**
+ * EVM Capability Helper.
+ *
+ * `CallContractRequest`, used by EVM capability, has arguments for reading a contract as specified in the call message at a block height defined by blockNumber.
+ * That blockNumber can be:
+ *  - the latest mined block (`LATEST_BLOCK_NUMBER`) (default)
+ * 	- the last finalized block (`LAST_FINALIZED_BLOCK_NUMBER`)
+ *
+ * Using this constant will indicate that the call should be executed at the last finalized block.
+ */
+export const LAST_FINALIZED_BLOCK_NUMBER = {
+	absVal: Buffer.from([3]).toString('base64'), // 3 for finalized block
+	sign: '-1',
+}
+
+/**
+ * EVM Capability Helper.
+ *
+ * `CallContractRequest`, used by EVM capability, has arguments for reading a contract as specified in the call message at a block height defined by blockNumber.
+ * That blockNumber can be:
+ *  - the latest mined block (`LATEST_BLOCK_NUMBER`) (default)
+ * 	- the last finalized block (`LAST_FINALIZED_BLOCK_NUMBER`)
+ *
+ * Using this constant will indicate that the call should be executed at the latest mined block.
+ */
+export const LATEST_BLOCK_NUMBER = {
+	absVal: Buffer.from([2]).toString('base64'), // 2 for the latest block
+	sign: '-1',
+}
+
+export interface EncodeCallMsgPayload {
+	from: Address
+	to: Address
+	data: Hex
+}
+
+/**
+ * Encodes a call message payload into a `CallMsgJson` protobuf structure, expected by the EVM capability.
+ *
+ * When creating a `CallContractRequest` 3 parameters are required:
+ *
+ * - `from` - The sender address.
+ * - `to` - The contract address.
+ * - `data` - The data to call the contract with.
+ *
+ * This helper wraps that data and packs into format acceptable by the EVM capability.
+ *
+ * @param payload - The call message payload to encode.
+ * @returns The encoded call message payload.
+ */
+export const encodeCallMsg = (payload: EncodeCallMsgPayload): CallMsgJson => ({
+	from: hexToBase64(payload.from),
+	to: hexToBase64(payload.to),
+	data: hexToBase64(payload.data),
+})

--- a/packages/cre-sdk/src/sdk/utils/capabilities/http/http-helpers.test.ts
+++ b/packages/cre-sdk/src/sdk/utils/capabilities/http/http-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import type { Response } from '../../generated/capabilities/networking/http/v1alpha/client_pb'
+import type { Response } from '@cre/generated/capabilities/networking/http/v1alpha/client_pb'
 import { getHeader, json, ok, text } from './http-helpers'
 
 // Mock Response object for testing

--- a/packages/cre-sdk/src/sdk/utils/capabilities/http/http-helpers.ts
+++ b/packages/cre-sdk/src/sdk/utils/capabilities/http/http-helpers.ts
@@ -1,4 +1,4 @@
-import type { Response } from '../../generated/capabilities/networking/http/v1alpha/client_pb'
+import type { Response } from '@cre/generated/capabilities/networking/http/v1alpha/client_pb'
 
 /**
  * HTTP Response Helper Functions

--- a/packages/cre-sdk/src/sdk/utils/index.ts
+++ b/packages/cre-sdk/src/sdk/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './capabilities/blockchain/blockchain-helpers'
 export * from './capabilities/http/http-helpers'
 export * from './chain-selectors'
 export * from './hex-utils'

--- a/packages/cre-sdk/src/sdk/utils/index.ts
+++ b/packages/cre-sdk/src/sdk/utils/index.ts
@@ -1,6 +1,6 @@
+export * from './capabilities/http/http-helpers'
 export * from './chain-selectors'
 export * from './hex-utils'
-export * from './http-helpers'
 export * from './values/consensus_aggregators'
 export * from './values/serializer_types'
 export * from './values/value'

--- a/packages/cre-sdk/src/sdk/utils/safeJsonStringify.ts
+++ b/packages/cre-sdk/src/sdk/utils/safeJsonStringify.ts
@@ -1,7 +1,0 @@
-/**
- * Supports stringifying an object with bigints, treating bigints as strings.
- * @param obj - The object to stringify
- * @returns The stringified object
- */
-export const safeJsonStringify = (obj: any): string =>
-	JSON.stringify(obj, (_, value) => (typeof value === 'bigint' ? value.toString() : value), 2)


### PR DESCRIPTION
Simplify `callContract` by providing utility method for users to abstract away `hexToBase64` encoding.