### PR TITLE
Allow ungrouped imports

### DIFF
--- a/packages/cre-sdk/package.json
+++ b/packages/cre-sdk/package.json
@@ -11,6 +11,10 @@
 		},
 		"./restricted-apis": {
 			"types": "./dist/restricted-apis.d.ts"
+		},
+		"./pb": {
+			"types": "./dist/pb.d.ts",
+			"import": "./dist/pb.js"
 		}
 	},
 	"bin": {

--- a/packages/cre-sdk/src/index.ts
+++ b/packages/cre-sdk/src/index.ts
@@ -2,8 +2,3 @@
 /// <reference types="./sdk/types/restricted-apis" />
 
 export * from './sdk'
-export * from './sdk/runtime'
-export * from './sdk/utils'
-// Export HTTP response helpers
-export * from './sdk/utils/capabilities/http/http-helpers'
-export * from './sdk/wasm'

--- a/packages/cre-sdk/src/pb.ts
+++ b/packages/cre-sdk/src/pb.ts
@@ -1,0 +1,6 @@
+export * as EVM_PB from '@cre/generated/capabilities/blockchain/evm/v1alpha/client_pb'
+export * as HTTP_CLIENT_PB from '@cre/generated/capabilities/networking/http/v1alpha/client_pb'
+export * as HTTP_TRIGGER_PB from '@cre/generated/capabilities/networking/http/v1alpha/trigger_pb'
+export * as CRON_TRIGGER_PB from '@cre/generated/capabilities/scheduler/cron/v1/trigger_pb'
+export * as SDK_PB from '@cre/generated/sdk/v1alpha/sdk_pb'
+export * as VALUES_PB from '@cre/generated/values/v1/values_pb'

--- a/packages/cre-sdk/src/sdk/cre/index.ts
+++ b/packages/cre-sdk/src/sdk/cre/index.ts
@@ -3,14 +3,15 @@
  */
 
 import { ClientCapability as EVMClient } from '@cre/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen'
-import {
-	ClientCapability as HTTPClient,
-	type SendRequester as HTTPSendRequester,
-} from '@cre/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen'
+import { ClientCapability as HTTPClient } from '@cre/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen'
 import { HTTPCapability } from '@cre/generated-sdk/capabilities/networking/http/v1alpha/http_sdk_gen'
 import { CronCapability } from '@cre/generated-sdk/capabilities/scheduler/cron/v1/cron_sdk_gen'
 import { prepareRuntime } from '@cre/sdk/utils/prepare-runtime'
 import { handler } from '@cre/sdk/workflow'
+
+/**
+ * Public exports for the CRE SDK.
+ */
 
 export {
 	type Log as EVMLog,
@@ -18,8 +19,20 @@ export {
 } from '@cre/generated/capabilities/blockchain/evm/v1alpha/client_pb'
 export type { Payload as HTTPPayload } from '@cre/generated/capabilities/networking/http/v1alpha/trigger_pb'
 export type { Payload as CronPayload } from '@cre/generated/capabilities/scheduler/cron/v1/trigger_pb'
+// EVM Capability
+export { ClientCapability as EVMClient } from '@cre/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen'
+// HTTP Capability
+export {
+	ClientCapability as HTTPClient,
+	type SendRequester as HTTPSendRequester,
+} from '@cre/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen'
+export { HTTPCapability } from '@cre/generated-sdk/capabilities/networking/http/v1alpha/http_sdk_gen'
+// CRON Capability
+export { CronCapability } from '@cre/generated-sdk/capabilities/scheduler/cron/v1/cron_sdk_gen'
+
+// Runtime
 export type { NodeRuntime, Runtime } from '@cre/sdk/runtime'
-export type { HTTPSendRequester }
+export { handler } from '@cre/sdk/workflow'
 
 prepareRuntime()
 

--- a/packages/cre-sdk/src/sdk/index.ts
+++ b/packages/cre-sdk/src/sdk/index.ts
@@ -1,5 +1,9 @@
-export * from "./cre";
-export * from "./report";
-export type * from "./runtime";
-export * from "./runtime";
-export * from "./workflow";
+export * from './cre'
+export * from './report'
+export type * from './runtime'
+export * from './runtime'
+export * from './utils'
+// Export HTTP response helpers
+export * from './utils/capabilities/http/http-helpers'
+export * from './wasm'
+export * from './workflow'

--- a/packages/cre-sdk/tsconfig.build.json
+++ b/packages/cre-sdk/tsconfig.build.json
@@ -36,6 +36,6 @@
 		"emitDecoratorMetadata": true
 	},
 
-	"include": ["src/index.ts", "src/sdk/**/*"],
+	"include": ["src/index.ts", "src/sdk/**/*", "src/pb.ts"],
 	"exclude": ["cli/**/*", "**/*.test.ts", "**/*.test.js"]
 }


### PR DESCRIPTION
- new export with lower level schemas
- ability to import capabilities without accessing them through `.cre.` object