### PR TITLE
Use cre cli 0.6.3-alpha version on CI

### DIFF
--- a/scripts/setup-cre-cli.sh
+++ b/scripts/setup-cre-cli.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Configuration
-VERSION="v0.6.2-alpha"
+VERSION="v0.6.3-alpha"
 PLATFORM="linux_amd64"
 FILENAME="cre_${PLATFORM}.tar.gz"
 BINARY_NAME="cre_${VERSION}_${PLATFORM}"


### PR DESCRIPTION
CI health checks would now be based on `v0.6.3-alpha` instead of `v0.6.2-alpha` of the `cre cli`.