### PR TITLE
Add Aptos capability client

### DIFF
--- a/packages/cre-sdk/scripts/src/generate-sdks.ts
+++ b/packages/cre-sdk/scripts/src/generate-sdks.ts
@@ -1,4 +1,5 @@
 import { rmSync } from 'node:fs'
+import { file_capabilities_blockchain_aptos_v1alpha_client } from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
 import { file_capabilities_blockchain_evm_v1alpha_client } from '@cre/generated/capabilities/blockchain/evm/v1alpha/client_pb'
 import { file_capabilities_internal_actionandtrigger_v1_action_and_trigger } from '@cre/generated/capabilities/internal/actionandtrigger/v1/action_and_trigger_pb'
 import { file_capabilities_internal_basicaction_v1_basic_action } from '@cre/generated/capabilities/internal/basicaction/v1/basic_action_pb'
@@ -57,6 +58,11 @@ export const main = () => {
 	)
 
 	// Production SDKs
+
+	generateSdk(file_capabilities_blockchain_aptos_v1alpha_client, './src/generated-sdk')
+	allMockExports.push(
+		...generateMocks(file_capabilities_blockchain_aptos_v1alpha_client, TEST_GENERATED_DIR),
+	)
 
 	generateSdk(file_capabilities_blockchain_evm_v1alpha_client, './src/generated-sdk')
 	allMockExports.push(

--- a/packages/cre-sdk/src/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen.ts
+++ b/packages/cre-sdk/src/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen.ts
@@ -1,42 +1,42 @@
+import { create, fromJson } from '@bufbuild/protobuf'
+import {
+	type AccountAPTBalanceReply,
+	AccountAPTBalanceReplySchema,
+	type AccountAPTBalanceRequest,
+	type AccountAPTBalanceRequestJson,
+	AccountAPTBalanceRequestSchema,
+	type AccountTransactionsReply,
+	AccountTransactionsReplySchema,
+	type AccountTransactionsRequest,
+	type AccountTransactionsRequestJson,
+	AccountTransactionsRequestSchema,
+	type GasConfig,
+	type GasConfigJson,
+	GasConfigSchema,
+	type TransactionByHashReply,
+	TransactionByHashReplySchema,
+	type TransactionByHashRequest,
+	type TransactionByHashRequestJson,
+	TransactionByHashRequestSchema,
+	type ViewReply,
+	ViewReplySchema,
+	type ViewRequest,
+	type ViewRequestJson,
+	ViewRequestSchema,
+	type WriteReportReply,
+	WriteReportReplySchema,
+	type WriteReportRequest,
+	type WriteReportRequestJson,
+	WriteReportRequestSchema,
+} from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
+import {
+	type ReportResponse,
+	type ReportResponseJson,
+	ReportResponseSchema,
+} from '@cre/generated/sdk/v1alpha/sdk_pb'
 import type { Runtime } from '@cre/sdk'
 import { Report } from '@cre/sdk/report'
 import { hexToBytes } from '@cre/sdk/utils/hex-utils'
-import { fromJson, create } from '@bufbuild/protobuf'
-import {
-	AccountAPTBalanceReplySchema,
-	AccountAPTBalanceRequestSchema,
-	AccountTransactionsReplySchema,
-	AccountTransactionsRequestSchema,
-	GasConfigSchema,
-	TransactionByHashReplySchema,
-	TransactionByHashRequestSchema,
-	ViewReplySchema,
-	ViewRequestSchema,
-	WriteReportReplySchema,
-	WriteReportRequestSchema,
-	type AccountAPTBalanceReply,
-	type AccountAPTBalanceRequest,
-	type AccountAPTBalanceRequestJson,
-	type AccountTransactionsReply,
-	type AccountTransactionsRequest,
-	type AccountTransactionsRequestJson,
-	type GasConfig,
-	type GasConfigJson,
-	type TransactionByHashReply,
-	type TransactionByHashRequest,
-	type TransactionByHashRequestJson,
-	type ViewReply,
-	type ViewRequest,
-	type ViewRequestJson,
-	type WriteReportReply,
-	type WriteReportRequest,
-	type WriteReportRequestJson,
-} from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
-import {
-	ReportResponseSchema,
-	type ReportResponse,
-	type ReportResponseJson,
-} from '@cre/generated/sdk/v1alpha/sdk_pb'
 
 export type WriteCreReportRequest = {
 	receiver: Uint8Array

--- a/packages/cre-sdk/src/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen.ts
+++ b/packages/cre-sdk/src/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen.ts
@@ -1,0 +1,295 @@
+import type { Runtime } from '@cre/sdk'
+import { Report } from '@cre/sdk/report'
+import { hexToBytes } from '@cre/sdk/utils/hex-utils'
+import { fromJson, create } from '@bufbuild/protobuf'
+import {
+	AccountAPTBalanceReplySchema,
+	AccountAPTBalanceRequestSchema,
+	AccountTransactionsReplySchema,
+	AccountTransactionsRequestSchema,
+	GasConfigSchema,
+	TransactionByHashReplySchema,
+	TransactionByHashRequestSchema,
+	ViewReplySchema,
+	ViewRequestSchema,
+	WriteReportReplySchema,
+	WriteReportRequestSchema,
+	type AccountAPTBalanceReply,
+	type AccountAPTBalanceRequest,
+	type AccountAPTBalanceRequestJson,
+	type AccountTransactionsReply,
+	type AccountTransactionsRequest,
+	type AccountTransactionsRequestJson,
+	type GasConfig,
+	type GasConfigJson,
+	type TransactionByHashReply,
+	type TransactionByHashRequest,
+	type TransactionByHashRequestJson,
+	type ViewReply,
+	type ViewRequest,
+	type ViewRequestJson,
+	type WriteReportReply,
+	type WriteReportRequest,
+	type WriteReportRequestJson,
+} from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
+import {
+	ReportResponseSchema,
+	type ReportResponse,
+	type ReportResponseJson,
+} from '@cre/generated/sdk/v1alpha/sdk_pb'
+
+export type WriteCreReportRequest = {
+	receiver: Uint8Array
+	gasConfig?: GasConfig
+	report?: Report
+	$report: true
+}
+
+export type WriteCreReportRequestJson = {
+	receiver: string
+	gasConfig?: GasConfigJson
+	report?: Report
+}
+
+export function x_generatedCodeOnly_wrap_WriteCreReportRequest(
+	input: WriteReportRequest,
+): WriteCreReportRequest {
+	return {
+		receiver: input.receiver,
+		gasConfig: input.gasConfig,
+		report: input.report !== undefined ? new Report(input.report) : undefined,
+		$report: true,
+	}
+}
+
+export function createWriteCreReportRequest(
+	input: WriteCreReportRequestJson,
+): WriteCreReportRequest {
+	return {
+		receiver: hexToBytes(input.receiver),
+		gasConfig:
+			input.gasConfig !== undefined ? fromJson(GasConfigSchema, input.gasConfig) : undefined,
+		report: input.report,
+		$report: true,
+	}
+}
+
+export function x_generatedCodeOnly_unwrap_WriteCreReportRequest(
+	input: WriteCreReportRequest,
+): WriteReportRequest {
+	return create(WriteReportRequestSchema, {
+		receiver: input.receiver,
+		gasConfig: input.gasConfig,
+		report: input.report !== undefined ? input.report.x_generatedCodeOnly_unwrap() : undefined,
+	})
+}
+
+/**
+ * Client Capability
+ *
+ * Capability ID: aptos@1.0.0
+ * Capability Name: aptos
+ * Capability Version: 1.0.0
+ */
+export class ClientCapability {
+	/** The capability ID for this service */
+	static readonly CAPABILITY_ID = 'aptos@1.0.0'
+
+	static readonly CAPABILITY_NAME = 'aptos'
+	static readonly CAPABILITY_VERSION = '1.0.0'
+
+	/** Available ChainSelector values */
+	static readonly SUPPORTED_CHAIN_SELECTORS = {
+		'aptos-mainnet': 4741433654826277614n,
+		'aptos-testnet': 743186221051783445n,
+	} as const
+
+	constructor(private readonly ChainSelector: bigint) {}
+
+	accountAPTBalance(
+		runtime: Runtime<unknown>,
+		input: AccountAPTBalanceRequest | AccountAPTBalanceRequestJson,
+	): { result: () => AccountAPTBalanceReply } {
+		// Handle input conversion - unwrap if it's a wrapped type, convert from JSON if needed
+		let payload: AccountAPTBalanceRequest
+
+		if ((input as unknown as { $typeName?: string }).$typeName) {
+			// It's the original protobuf type
+			payload = input as AccountAPTBalanceRequest
+		} else {
+			// It's regular JSON, convert using fromJson
+			payload = fromJson(AccountAPTBalanceRequestSchema, input as AccountAPTBalanceRequestJson)
+		}
+
+		// Include all labels in capability ID for routing when specified
+		const capabilityId = `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.ChainSelector}@${ClientCapability.CAPABILITY_VERSION}`
+
+		const capabilityResponse = runtime.callCapability<
+			AccountAPTBalanceRequest,
+			AccountAPTBalanceReply
+		>({
+			capabilityId,
+			method: 'AccountAPTBalance',
+			payload,
+			inputSchema: AccountAPTBalanceRequestSchema,
+			outputSchema: AccountAPTBalanceReplySchema,
+		})
+
+		return {
+			result: () => {
+				const result = capabilityResponse.result()
+
+				return result
+			},
+		}
+	}
+
+	view(
+		runtime: Runtime<unknown>,
+		input: ViewRequest | ViewRequestJson,
+	): { result: () => ViewReply } {
+		// Handle input conversion - unwrap if it's a wrapped type, convert from JSON if needed
+		let payload: ViewRequest
+
+		if ((input as unknown as { $typeName?: string }).$typeName) {
+			// It's the original protobuf type
+			payload = input as ViewRequest
+		} else {
+			// It's regular JSON, convert using fromJson
+			payload = fromJson(ViewRequestSchema, input as ViewRequestJson)
+		}
+
+		// Include all labels in capability ID for routing when specified
+		const capabilityId = `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.ChainSelector}@${ClientCapability.CAPABILITY_VERSION}`
+
+		const capabilityResponse = runtime.callCapability<ViewRequest, ViewReply>({
+			capabilityId,
+			method: 'View',
+			payload,
+			inputSchema: ViewRequestSchema,
+			outputSchema: ViewReplySchema,
+		})
+
+		return {
+			result: () => {
+				const result = capabilityResponse.result()
+
+				return result
+			},
+		}
+	}
+
+	transactionByHash(
+		runtime: Runtime<unknown>,
+		input: TransactionByHashRequest | TransactionByHashRequestJson,
+	): { result: () => TransactionByHashReply } {
+		// Handle input conversion - unwrap if it's a wrapped type, convert from JSON if needed
+		let payload: TransactionByHashRequest
+
+		if ((input as unknown as { $typeName?: string }).$typeName) {
+			// It's the original protobuf type
+			payload = input as TransactionByHashRequest
+		} else {
+			// It's regular JSON, convert using fromJson
+			payload = fromJson(TransactionByHashRequestSchema, input as TransactionByHashRequestJson)
+		}
+
+		// Include all labels in capability ID for routing when specified
+		const capabilityId = `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.ChainSelector}@${ClientCapability.CAPABILITY_VERSION}`
+
+		const capabilityResponse = runtime.callCapability<
+			TransactionByHashRequest,
+			TransactionByHashReply
+		>({
+			capabilityId,
+			method: 'TransactionByHash',
+			payload,
+			inputSchema: TransactionByHashRequestSchema,
+			outputSchema: TransactionByHashReplySchema,
+		})
+
+		return {
+			result: () => {
+				const result = capabilityResponse.result()
+
+				return result
+			},
+		}
+	}
+
+	accountTransactions(
+		runtime: Runtime<unknown>,
+		input: AccountTransactionsRequest | AccountTransactionsRequestJson,
+	): { result: () => AccountTransactionsReply } {
+		// Handle input conversion - unwrap if it's a wrapped type, convert from JSON if needed
+		let payload: AccountTransactionsRequest
+
+		if ((input as unknown as { $typeName?: string }).$typeName) {
+			// It's the original protobuf type
+			payload = input as AccountTransactionsRequest
+		} else {
+			// It's regular JSON, convert using fromJson
+			payload = fromJson(AccountTransactionsRequestSchema, input as AccountTransactionsRequestJson)
+		}
+
+		// Include all labels in capability ID for routing when specified
+		const capabilityId = `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.ChainSelector}@${ClientCapability.CAPABILITY_VERSION}`
+
+		const capabilityResponse = runtime.callCapability<
+			AccountTransactionsRequest,
+			AccountTransactionsReply
+		>({
+			capabilityId,
+			method: 'AccountTransactions',
+			payload,
+			inputSchema: AccountTransactionsRequestSchema,
+			outputSchema: AccountTransactionsReplySchema,
+		})
+
+		return {
+			result: () => {
+				const result = capabilityResponse.result()
+
+				return result
+			},
+		}
+	}
+
+	writeReport(
+		runtime: Runtime<unknown>,
+		input: WriteCreReportRequest | WriteCreReportRequestJson,
+	): { result: () => WriteReportReply } {
+		// Handle input conversion - unwrap if it's a wrapped type, convert from JSON if needed
+		let payload: WriteReportRequest
+
+		// Check if it's a wrapped type by looking for the $report property
+		if ((input as unknown as { $report?: boolean }).$report) {
+			// It's a wrapped type, unwrap it
+			payload = x_generatedCodeOnly_unwrap_WriteCreReportRequest(input as WriteCreReportRequest)
+		} else {
+			// It's wrapped JSON, convert using create function
+			payload = x_generatedCodeOnly_unwrap_WriteCreReportRequest(
+				createWriteCreReportRequest(input as WriteCreReportRequestJson),
+			)
+		}
+
+		// Include all labels in capability ID for routing when specified
+		const capabilityId = `${ClientCapability.CAPABILITY_NAME}:ChainSelector:${this.ChainSelector}@${ClientCapability.CAPABILITY_VERSION}`
+
+		const capabilityResponse = runtime.callCapability<WriteReportRequest, WriteReportReply>({
+			capabilityId,
+			method: 'WriteReport',
+			payload,
+			inputSchema: WriteReportRequestSchema,
+			outputSchema: WriteReportReplySchema,
+		})
+
+		return {
+			result: () => {
+				const result = capabilityResponse.result()
+
+				return result
+			},
+		}
+	}
+}

--- a/packages/cre-sdk/src/sdk/cre/index.ts
+++ b/packages/cre-sdk/src/sdk/cre/index.ts
@@ -17,16 +17,16 @@ import { handler } from '@cre/sdk/workflow'
 
 export { TxStatus as AptosTxStatus } from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
 export {
-	ClientCapability as AptosClient,
-	type WriteCreReportRequest as AptosWriteCreReportRequest,
-	type WriteCreReportRequestJson as AptosWriteCreReportRequestJson,
-} from '@cre/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen'
-export {
 	type Log as EVMLog,
 	TxStatus,
 } from '@cre/generated/capabilities/blockchain/evm/v1alpha/client_pb'
 export type { Payload as HTTPPayload } from '@cre/generated/capabilities/networking/http/v1alpha/trigger_pb'
 export type { Payload as CronPayload } from '@cre/generated/capabilities/scheduler/cron/v1/trigger_pb'
+export {
+	ClientCapability as AptosClient,
+	type WriteCreReportRequest as AptosWriteCreReportRequest,
+	type WriteCreReportRequestJson as AptosWriteCreReportRequestJson,
+} from '@cre/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen'
 
 // EVM Capability
 export {

--- a/packages/cre-sdk/src/sdk/cre/index.ts
+++ b/packages/cre-sdk/src/sdk/cre/index.ts
@@ -2,6 +2,7 @@
  * Public API for the CRE SDK.
  */
 
+import { ClientCapability as AptosClient } from '@cre/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen'
 import { ClientCapability as EVMClient } from '@cre/generated-sdk/capabilities/blockchain/evm/v1alpha/client_sdk_gen'
 import { ClientCapability as ConfidentialHTTPClient } from '@cre/generated-sdk/capabilities/networking/confidentialhttp/v1alpha/client_sdk_gen'
 import { ClientCapability as HTTPClient } from '@cre/generated-sdk/capabilities/networking/http/v1alpha/client_sdk_gen'
@@ -14,6 +15,12 @@ import { handler } from '@cre/sdk/workflow'
  * Public exports for the CRE SDK.
  */
 
+export { TxStatus as AptosTxStatus } from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
+export {
+	ClientCapability as AptosClient,
+	type WriteCreReportRequest as AptosWriteCreReportRequest,
+	type WriteCreReportRequestJson as AptosWriteCreReportRequestJson,
+} from '@cre/generated-sdk/capabilities/blockchain/aptos/v1alpha/client_sdk_gen'
 export {
 	type Log as EVMLog,
 	TxStatus,
@@ -47,6 +54,7 @@ prepareRuntime()
 
 export const cre = {
 	capabilities: {
+		AptosClient,
 		CronCapability,
 		HTTPCapability,
 		ConfidentialHTTPClient,

--- a/packages/cre-sdk/src/sdk/test/generated/capabilities/blockchain/aptos/v1alpha/aptos_mock_gen.ts
+++ b/packages/cre-sdk/src/sdk/test/generated/capabilities/blockchain/aptos/v1alpha/aptos_mock_gen.ts
@@ -1,11 +1,6 @@
 import { fromJson } from '@bufbuild/protobuf'
 import { anyPack, anyUnpack } from '@bufbuild/protobuf/wkt'
 import {
-	registerTestCapability,
-	__getTestMockInstance,
-	__setTestMockInstance,
-} from '@cre/sdk/testutils/test-runtime'
-import {
 	type AccountAPTBalanceReply,
 	type AccountAPTBalanceReplyJson,
 	AccountAPTBalanceReplySchema,
@@ -32,6 +27,11 @@ import {
 	type WriteReportRequest,
 	WriteReportRequestSchema,
 } from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
+import {
+	__getTestMockInstance,
+	__setTestMockInstance,
+	registerTestCapability,
+} from '@cre/sdk/testutils/test-runtime'
 
 /**
  * Mock for ClientCapability. Use testInstance() to obtain an instance; do not construct directly.

--- a/packages/cre-sdk/src/sdk/test/generated/capabilities/blockchain/aptos/v1alpha/aptos_mock_gen.ts
+++ b/packages/cre-sdk/src/sdk/test/generated/capabilities/blockchain/aptos/v1alpha/aptos_mock_gen.ts
@@ -1,0 +1,180 @@
+import { fromJson } from '@bufbuild/protobuf'
+import { anyPack, anyUnpack } from '@bufbuild/protobuf/wkt'
+import {
+	registerTestCapability,
+	__getTestMockInstance,
+	__setTestMockInstance,
+} from '@cre/sdk/testutils/test-runtime'
+import {
+	type AccountAPTBalanceReply,
+	type AccountAPTBalanceReplyJson,
+	AccountAPTBalanceReplySchema,
+	type AccountAPTBalanceRequest,
+	AccountAPTBalanceRequestSchema,
+	type AccountTransactionsReply,
+	type AccountTransactionsReplyJson,
+	AccountTransactionsReplySchema,
+	type AccountTransactionsRequest,
+	AccountTransactionsRequestSchema,
+	type TransactionByHashReply,
+	type TransactionByHashReplyJson,
+	TransactionByHashReplySchema,
+	type TransactionByHashRequest,
+	TransactionByHashRequestSchema,
+	type ViewReply,
+	type ViewReplyJson,
+	ViewReplySchema,
+	type ViewRequest,
+	ViewRequestSchema,
+	type WriteReportReply,
+	type WriteReportReplyJson,
+	WriteReportReplySchema,
+	type WriteReportRequest,
+	WriteReportRequestSchema,
+} from '@cre/generated/capabilities/blockchain/aptos/v1alpha/client_pb'
+
+/**
+ * Mock for ClientCapability. Use testInstance() to obtain an instance; do not construct directly.
+ * Set per-method properties (e.g. performAction) to define return values. If a method is invoked without a handler set, an error is thrown.
+ */
+export class AptosMock {
+	static readonly CAPABILITY_ID = 'aptos@1.0.0'
+
+	/** Set to define the return value for AccountAPTBalance. May return a plain object (AccountAPTBalanceReplyJson) or the message type. */
+	accountAPTBalance?: (
+		input: AccountAPTBalanceRequest,
+	) => AccountAPTBalanceReply | AccountAPTBalanceReplyJson
+
+	/** Set to define the return value for View. May return a plain object (ViewReplyJson) or the message type. */
+	view?: (input: ViewRequest) => ViewReply | ViewReplyJson
+
+	/** Set to define the return value for TransactionByHash. May return a plain object (TransactionByHashReplyJson) or the message type. */
+	transactionByHash?: (
+		input: TransactionByHashRequest,
+	) => TransactionByHashReply | TransactionByHashReplyJson
+
+	/** Set to define the return value for AccountTransactions. May return a plain object (AccountTransactionsReplyJson) or the message type. */
+	accountTransactions?: (
+		input: AccountTransactionsRequest,
+	) => AccountTransactionsReply | AccountTransactionsReplyJson
+
+	/** Set to define the return value for WriteReport. May return a plain object (WriteReportReplyJson) or the message type. */
+	writeReport?: (input: WriteReportRequest) => WriteReportReply | WriteReportReplyJson
+
+	private constructor(chainSelector: bigint) {
+		const self = this
+		const qualifiedId = `aptos:ChainSelector:${chainSelector}@1.0.0`
+		try {
+			registerTestCapability(qualifiedId, (req) => {
+				switch (req.method) {
+					case 'AccountAPTBalance': {
+						const input = anyUnpack(
+							req.payload,
+							AccountAPTBalanceRequestSchema,
+						) as AccountAPTBalanceRequest
+						const handler = self.accountAPTBalance
+						if (typeof handler !== 'function')
+							throw new Error(
+								"AccountAPTBalance: no implementation provided; set the mock's accountAPTBalance property to define the return value.",
+							)
+						const raw = handler(input)
+						const output =
+							raw && typeof (raw as unknown as { $typeName?: string }).$typeName === 'string'
+								? (raw as AccountAPTBalanceReply)
+								: fromJson(AccountAPTBalanceReplySchema, raw as AccountAPTBalanceReplyJson)
+						return {
+							response: { case: 'payload', value: anyPack(AccountAPTBalanceReplySchema, output) },
+						}
+					}
+					case 'View': {
+						const input = anyUnpack(req.payload, ViewRequestSchema) as ViewRequest
+						const handler = self.view
+						if (typeof handler !== 'function')
+							throw new Error(
+								"View: no implementation provided; set the mock's view property to define the return value.",
+							)
+						const raw = handler(input)
+						const output =
+							raw && typeof (raw as unknown as { $typeName?: string }).$typeName === 'string'
+								? (raw as ViewReply)
+								: fromJson(ViewReplySchema, raw as ViewReplyJson)
+						return { response: { case: 'payload', value: anyPack(ViewReplySchema, output) } }
+					}
+					case 'TransactionByHash': {
+						const input = anyUnpack(
+							req.payload,
+							TransactionByHashRequestSchema,
+						) as TransactionByHashRequest
+						const handler = self.transactionByHash
+						if (typeof handler !== 'function')
+							throw new Error(
+								"TransactionByHash: no implementation provided; set the mock's transactionByHash property to define the return value.",
+							)
+						const raw = handler(input)
+						const output =
+							raw && typeof (raw as unknown as { $typeName?: string }).$typeName === 'string'
+								? (raw as TransactionByHashReply)
+								: fromJson(TransactionByHashReplySchema, raw as TransactionByHashReplyJson)
+						return {
+							response: { case: 'payload', value: anyPack(TransactionByHashReplySchema, output) },
+						}
+					}
+					case 'AccountTransactions': {
+						const input = anyUnpack(
+							req.payload,
+							AccountTransactionsRequestSchema,
+						) as AccountTransactionsRequest
+						const handler = self.accountTransactions
+						if (typeof handler !== 'function')
+							throw new Error(
+								"AccountTransactions: no implementation provided; set the mock's accountTransactions property to define the return value.",
+							)
+						const raw = handler(input)
+						const output =
+							raw && typeof (raw as unknown as { $typeName?: string }).$typeName === 'string'
+								? (raw as AccountTransactionsReply)
+								: fromJson(AccountTransactionsReplySchema, raw as AccountTransactionsReplyJson)
+						return {
+							response: { case: 'payload', value: anyPack(AccountTransactionsReplySchema, output) },
+						}
+					}
+					case 'WriteReport': {
+						const input = anyUnpack(req.payload, WriteReportRequestSchema) as WriteReportRequest
+						const handler = self.writeReport
+						if (typeof handler !== 'function')
+							throw new Error(
+								"WriteReport: no implementation provided; set the mock's writeReport property to define the return value.",
+							)
+						const raw = handler(input)
+						const output =
+							raw && typeof (raw as unknown as { $typeName?: string }).$typeName === 'string'
+								? (raw as WriteReportReply)
+								: fromJson(WriteReportReplySchema, raw as WriteReportReplyJson)
+						return { response: { case: 'payload', value: anyPack(WriteReportReplySchema, output) } }
+					}
+					default:
+						return { response: { case: 'error', value: `unknown method ${req.method}` } }
+				}
+			})
+		} catch {
+			throw new Error(
+				"Capability mocks must be used within the CRE test framework's test() method.",
+			)
+		}
+	}
+
+	/**
+	 * Returns the mock instance for this capability and the specified tags.
+	 * Multiple calls with the same tag values return the same instance.
+	 * Must be called within the test framework's test() method.
+	 */
+	static testInstance(chainSelector: bigint): AptosMock {
+		const qualifiedId = `aptos:ChainSelector:${chainSelector}@1.0.0`
+		let instance = __getTestMockInstance<AptosMock>(qualifiedId)
+		if (!instance) {
+			instance = new AptosMock(chainSelector)
+			__setTestMockInstance(qualifiedId, instance)
+		}
+		return instance
+	}
+}

--- a/packages/cre-sdk/src/sdk/test/generated/index.ts
+++ b/packages/cre-sdk/src/sdk/test/generated/index.ts
@@ -1,9 +1,10 @@
 /** Auto-generated barrel of capability mocks. Do not edit. */
 
-export { EvmMock } from './capabilities/blockchain/evm/v1alpha/evm_mock_gen'
-export { BasicTestActionTriggerMock } from './capabilities/internal/actionandtrigger/v1/basic_test_action_trigger_mock_gen'
 export { BasicTestActionMock } from './capabilities/internal/basicaction/v1/basic_test_action_mock_gen'
-export { ConsensusMock } from './capabilities/internal/consensus/v1alpha/consensus_mock_gen'
 export { BasicTestNodeActionMock } from './capabilities/internal/nodeaction/v1/basic_test_node_action_mock_gen'
-export { ConfidentialHttpMock } from './capabilities/networking/confidentialhttp/v1alpha/confidential_http_mock_gen'
+export { ConsensusMock } from './capabilities/internal/consensus/v1alpha/consensus_mock_gen'
+export { BasicTestActionTriggerMock } from './capabilities/internal/actionandtrigger/v1/basic_test_action_trigger_mock_gen'
+export { AptosMock } from './capabilities/blockchain/aptos/v1alpha/aptos_mock_gen'
+export { EvmMock } from './capabilities/blockchain/evm/v1alpha/evm_mock_gen'
 export { HttpActionsMock } from './capabilities/networking/http/v1alpha/http_actions_mock_gen'
+export { ConfidentialHttpMock } from './capabilities/networking/confidentialhttp/v1alpha/confidential_http_mock_gen'

--- a/packages/cre-sdk/src/sdk/test/generated/index.ts
+++ b/packages/cre-sdk/src/sdk/test/generated/index.ts
@@ -1,10 +1,10 @@
 /** Auto-generated barrel of capability mocks. Do not edit. */
 
-export { BasicTestActionMock } from './capabilities/internal/basicaction/v1/basic_test_action_mock_gen'
-export { BasicTestNodeActionMock } from './capabilities/internal/nodeaction/v1/basic_test_node_action_mock_gen'
-export { ConsensusMock } from './capabilities/internal/consensus/v1alpha/consensus_mock_gen'
-export { BasicTestActionTriggerMock } from './capabilities/internal/actionandtrigger/v1/basic_test_action_trigger_mock_gen'
 export { AptosMock } from './capabilities/blockchain/aptos/v1alpha/aptos_mock_gen'
 export { EvmMock } from './capabilities/blockchain/evm/v1alpha/evm_mock_gen'
-export { HttpActionsMock } from './capabilities/networking/http/v1alpha/http_actions_mock_gen'
+export { BasicTestActionTriggerMock } from './capabilities/internal/actionandtrigger/v1/basic_test_action_trigger_mock_gen'
+export { BasicTestActionMock } from './capabilities/internal/basicaction/v1/basic_test_action_mock_gen'
+export { ConsensusMock } from './capabilities/internal/consensus/v1alpha/consensus_mock_gen'
+export { BasicTestNodeActionMock } from './capabilities/internal/nodeaction/v1/basic_test_node_action_mock_gen'
 export { ConfidentialHttpMock } from './capabilities/networking/confidentialhttp/v1alpha/confidential_http_mock_gen'
+export { HttpActionsMock } from './capabilities/networking/http/v1alpha/http_actions_mock_gen'


### PR DESCRIPTION
Summary

- Add Aptos (aptos@1.0.0) to the SDK generation pipeline in generate-sdks.ts so client_sdk_gen.ts and test mocks are auto-generated from the existing proto definitions.
- Export AptosClient, AptosTxStatus, and related types from the public SDK API in cre/index.ts.
- Generated client exposes all Aptos RPCs: accountAPTBalance, view, transactionByHash, accountTransactions, and writeReport.

Why
The Aptos proto definitions (client_pb.ts) and chain selectors already ship in v1.5.0 but the capability client wrapper was never generated or exported. This blocks downstream workflows from integrating Aptos chain support.