### PR TITLE
Unlock CI

### DIFF
--- a/.github/workflows/validate-submodule.yml
+++ b/.github/workflows/validate-submodule.yml
@@ -4,12 +4,12 @@ permissions: {}
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [capabilities-development]
   push:
     branches: [capabilities-development]
 
 jobs:
   validate-submodule:
+    if: github.event_name == 'push' || github.base_ref == 'capabilities-development'
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/packages/cre-sdk-examples/src/workflows/log-trigger/index.ts
+++ b/packages/cre-sdk-examples/src/workflows/log-trigger/index.ts
@@ -5,6 +5,7 @@ import {
 	type EVMLog,
 	getNetwork,
 	handler,
+	logTriggerConfig,
 	protoBigIntToBigint,
 	Runner,
 	type Runtime,
@@ -74,11 +75,18 @@ const initWorkflow = (config: Config) => {
 		return 'success'
 	}
 
+	// keccak256("MessageEmitted(address,uint256,string)")
+	const MESSAGE_EMITTED_TOPIC =
+		'0xc799f359194674b273986b8c03283265390f642b631c04e6526b99d0d8f4c38d' as `0x${string}`
+
 	return [
 		handler(
-			evmClient.logTrigger({
-				addresses: [config.evms[0].messageEmitterAddress],
-			}),
+			evmClient.logTrigger(
+				logTriggerConfig({
+					addresses: [config.evms[0].messageEmitterAddress as `0x${string}`],
+					topics: [[MESSAGE_EMITTED_TOPIC]],
+				}),
+			),
 			onLogTrigger,
 		),
 	]


### PR DESCRIPTION
`validate submodule` job should no longer run on PRs targeting `main` branch, unlocking the CI.

Also includes this (as it was another CI blocker): https://github.com/smartcontractkit/cre-sdk-typescript/pull/233